### PR TITLE
feat: add dns cache when enable zju-dns to speed up

### DIFF
--- a/core/EasyConnectClient.go
+++ b/core/EasyConnectClient.go
@@ -1,12 +1,13 @@
 package core
 
 import (
-	"ZJUConnect/parser"
 	"errors"
 	"fmt"
 	"log"
 	"net"
 	"runtime"
+
+	"ZJUConnect/parser"
 
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 )
@@ -18,6 +19,7 @@ var ParseServConfig bool
 var ParseZjuConfig bool
 var ProxyAll bool
 var UseZjuDns bool
+var DnsTTL uint64
 
 type EasyConnectClient struct {
 	queryConn net.Conn

--- a/core/dns_cache.go
+++ b/core/dns_cache.go
@@ -1,0 +1,49 @@
+package core
+
+import (
+	"log"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+)
+
+// only store domain -> ip, don't store ip -> ip
+var dnsCaches *DnsCache
+var once sync.Once
+
+type DnsCache struct {
+	cache *cache.Cache
+}
+
+func GetDnsCache(host string) (net.IP, bool) {
+	once.Do(func() {
+		dnsCaches = &DnsCache{
+			cache: cache.New(time.Duration(DnsTTL)*time.Second, time.Duration(DnsTTL)*2*time.Second),
+		}
+	})
+	if item, found := dnsCaches.cache.Get(host); found {
+		if DebugDump {
+			log.Printf("GetDnsCache: %s -> %s", host, item.(net.IP).String())
+		}
+		return item.(net.IP), found
+	} else {
+		if DebugDump {
+			log.Printf("GetDnsCache: %s -> not found", host)
+		}
+		return nil, found
+	}
+}
+
+func SetDnsCache(host string, ip net.IP) {
+	once.Do(func() {
+		dnsCaches = &DnsCache{
+			cache: cache.New(time.Duration(DnsTTL)*time.Second, time.Duration(DnsTTL)*2*time.Second),
+		}
+	})
+	if DebugDump {
+		log.Printf("SetDnsCache: %s -> %s", host, ip.String())
+	}
+	dnsCaches.cache.Set(host, ip, cache.DefaultExpiration)
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require github.com/refraction-networking/utls v1.2.0
 require (
 	github.com/cornelk/hashmap v1.0.8
 	github.com/dlclark/regexp2 v1.8.0
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	golang.org/x/net v0.5.0
 	gvisor.dev/gvisor v0.0.0-20230128000341-b7014294633b
 	tailscale.com v1.36.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/klauspost/compress v1.15.12 h1:YClS/PImqYbn+UILDnqxQCZ3RehC9N318SU3kE
 github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/refraction-networking/utls v1.2.0 h1:U5f8wkij2NVinfLuJdFP3gCMwIHs+EzvhxmYdXgiapo=
 github.com/refraction-networking/utls v1.2.0/go.mod h1:NPq+cVqzH7D1BeOkmOcb5O/8iVewAsiVt2x1/eO0hgQ=
 github.com/rogpeppe/go-internal v1.8.1-0.20211023094830-115ce09fd6b4 h1:Ha8xCaq6ln1a+R91Km45Oq6lPXj2Mla6CRJYcuV2h1w=

--- a/main.go
+++ b/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"ZJUConnect/core"
-	"ZJUConnect/listener"
 	"flag"
 	"log"
+
+	"ZJUConnect/core"
+	"ZJUConnect/listener"
 )
 
 func main() {
@@ -22,6 +23,7 @@ func main() {
 	flag.BoolVar(&core.ParseZjuConfig, "parse-zju", false, "Parse ZJU config")
 	flag.BoolVar(&core.ProxyAll, "proxy-all", false, "Proxy all IPv4 traffic")
 	flag.BoolVar(&core.UseZjuDns, "use-zju-dns", false, "Use ZJU DNS")
+	flag.Uint64Var(&core.DnsTTL, "dns-ttl", 3600, "Dns record time to live, unit is second")
 	flag.Parse()
 
 	if host == "" || ((username == "" || password == "") && twfId == "") {


### PR DESCRIPTION
1. add a `dns-ttl` flag to control dns record time to live, unit is second
2. use `go-cache` library to create a dns cache pool, enable get and set