### PR TITLE
fix: err not updated after OTP authentication

### DIFF
--- a/core/EasyConnectClient.go
+++ b/core/EasyConnectClient.go
@@ -73,21 +73,21 @@ func StartClient(host string, port int, username string, password string, twfId 
 		if err == ERR_NEXT_AUTH_SMS {
 			fmt.Print(">>>Please enter your sms code<<<:")
 			smsCode := ""
-			_, err := fmt.Scan(&smsCode)
-			if err != nil {
-				panic(err)
+			_, _err := fmt.Scan(&smsCode)
+			if _err != nil {
+				panic(_err)
 			}
 
-			_ = client.AuthSMSCode(smsCode)
+			err = client.AuthSMSCode(smsCode)
 		} else if err == ERR_NEXT_AUTH_TOTP {
 			fmt.Print(">>>Please enter your TOTP Auth code<<<:")
 			TOTPCode := ""
-			_, err := fmt.Scan(&TOTPCode)
-			if err != nil {
-				panic(err)
+			_, _err := fmt.Scan(&TOTPCode)
+			if _err != nil {
+				panic(_err)
 			}
 
-			_ = client.AuthTOTP(TOTPCode)
+			err = client.AuthTOTP(TOTPCode)
 		}
 	}
 


### PR DESCRIPTION
Previously, `err` was not updated after `client.AuthSMSCode(smsCode)` or `client.AuthTOTP(TOTPCode)`. As a result, even after successful authentication, the code would still panic at `core/EasyConnectClient.go#L118`:

```golang
	// check error after trying best server
	if err != nil {
		log.Fatal(err.Error())
	}
```