### PR TITLE
feat: only use one query for concurrent dns query #48

### DIFF
--- a/resolve/resolver.go
+++ b/resolve/resolver.go
@@ -25,7 +25,12 @@ type Resolver struct {
 
 	timer  *time.Timer
 	useTCP bool
-	lock   sync.RWMutex
+	// check to use tcp resolver or udp resolver
+	tcpLock sync.RWMutex
+	// check to handle concurrent same dns query
+	// only the goroutine which get the lock can use remoteResolver
+	// MUST handler lock/unlock carefully!
+	concurResolveLock sync.Map
 }
 
 // Resolve ip address. If the host should be visited via VPN, this function set a USE_VPN value in context
@@ -56,45 +61,61 @@ func (r *Resolver) Resolve(ctx context.Context, host string) (context.Context, n
 	}
 
 	if r.useRemoteDNS {
-		r.lock.RLock()
+		r.tcpLock.RLock()
 		useTCP := r.useTCP
-		r.lock.RUnlock()
-
-		if !useTCP {
-			ips, err := r.remoteUDPResolver.LookupIP(context.Background(), "ip4", host)
-			if err != nil {
-				if ips, err = r.remoteTCPResolver.LookupIP(context.Background(), "ip4", host); err != nil {
-					// All remote DNS failed, so we keep do nothing but use secondary dns
-					log.Printf("Resolve IPv4 addr failed using ZJU UDP/TCP DNS: " + host + ", using secondary DNS instead")
-					return r.ResolveWithSecondaryDNS(ctx, host)
-				} else {
-					r.lock.Lock()
-					r.useTCP = true
-					if r.timer == nil {
-						r.timer = time.AfterFunc(10*time.Minute, func() {
-							r.lock.Lock()
-							r.useTCP = false
-							r.timer = nil
-							r.lock.Unlock()
-						})
+		r.tcpLock.RUnlock()
+		resolveLockItem, _ := r.concurResolveLock.LoadOrStore(host, new(sync.Mutex))
+		resolveLock := resolveLockItem.(*sync.Mutex)
+		if resolveLock.TryLock() {
+			if !useTCP {
+				ips, err := r.remoteUDPResolver.LookupIP(context.Background(), "ip4", host)
+				if err != nil {
+					if ips, err = r.remoteTCPResolver.LookupIP(context.Background(), "ip4", host); err != nil {
+						resolveLock.Unlock()
+						// All remote DNS failed, so we keep do nothing but use secondary dns
+						log.Printf("Resolve IPv4 addr failed using ZJU UDP/TCP DNS: " + host + ", using secondary DNS instead")
+						return r.ResolveWithSecondaryDNS(ctx, host)
+					} else {
+						r.tcpLock.Lock()
+						r.useTCP = true
+						if r.timer == nil {
+							r.timer = time.AfterFunc(10*time.Minute, func() {
+								r.tcpLock.Lock()
+								r.useTCP = false
+								r.timer = nil
+								r.tcpLock.Unlock()
+							})
+						}
+						r.tcpLock.Unlock()
 					}
-					r.lock.Unlock()
 				}
-			}
-			// Set DNS cache if tcp or udp DNS success
-			r.setDNSCache(host, ips[0])
-			log.Printf("%s -> %s", host, ips[0].String())
-			return ctx, ips[0], nil
-		} else {
-			// Only try tcp and secondary DNS
-			if ips, err := r.remoteTCPResolver.LookupIP(context.Background(), "ip4", host); err != nil {
-				log.Printf("Resolve IPv4 addr failed using ZJU TCP DNS: " + host + ", using secondary DNS instead")
-				return r.ResolveWithSecondaryDNS(ctx, host)
-			} else {
+				// Set DNS cache if tcp or udp DNS success
 				r.setDNSCache(host, ips[0])
+				resolveLock.Unlock()
 				log.Printf("%s -> %s", host, ips[0].String())
 				return ctx, ips[0], nil
+			} else {
+				// Only try tcp and secondary DNS
+				if ips, err := r.remoteTCPResolver.LookupIP(context.Background(), "ip4", host); err != nil {
+					resolveLock.Unlock()
+					log.Printf("Resolve IPv4 addr failed using ZJU TCP DNS: " + host + ", using secondary DNS instead")
+					return r.ResolveWithSecondaryDNS(ctx, host)
+				} else {
+					r.setDNSCache(host, ips[0])
+					resolveLock.Unlock()
+					log.Printf("%s -> %s", host, ips[0].String())
+					return ctx, ips[0], nil
+				}
 			}
+		} else {
+			// waiting dns query for remoteResolve finish
+			resolveLock.Lock()
+			resolveLock.Unlock()
+			// if host handled by remoteResolver, it must exist in DNSCache
+			if cachedIP, found := r.getDNSCache(host); found {
+				return ctx, cachedIP, nil
+			}
+			return r.ResolveWithSecondaryDNS(ctx, host)
 		}
 	} else {
 		return r.ResolveWithSecondaryDNS(ctx, host)

--- a/stack/tun/stack.go
+++ b/stack/tun/stack.go
@@ -170,7 +170,7 @@ func (s *Stack) shouldHijackUDPDns(ipHeader zctcpip.IPv4Packet, udpHeader zctcpi
 }
 
 func (s *Stack) doHijackUDPDns(ipHeader zctcpip.IPv4Packet, udpHeader zctcpip.UDPPacket) {
-	log.Printf("hijack dns %s:%d -> %s:%d", ipHeader.SourceIP(), udpHeader.SourcePort(), ipHeader.DestinationIP(), udpHeader.DestinationPort())
+	log.DebugPrintf("hijack dns %s:%d -> %s:%d", ipHeader.SourceIP(), udpHeader.SourcePort(), ipHeader.DestinationIP(), udpHeader.DestinationPort())
 	msg := dns.Msg{}
 	if err := msg.Unpack(udpHeader.Payload()); err != nil {
 		log.Printf("unpack dns msg error: %v", err)
@@ -178,7 +178,7 @@ func (s *Stack) doHijackUDPDns(ipHeader zctcpip.IPv4Packet, udpHeader zctcpip.UD
 	}
 	resMsg, err := s.resolve.HandleDnsMsg(context.Background(), &msg)
 	if err != nil {
-		log.Printf("hijack dns error: %v", err)
+		log.Printf("hijack dns %s:%d -> %s:%d error: %v", ipHeader.SourceIP(), udpHeader.SourcePort(), ipHeader.DestinationIP(), udpHeader.DestinationPort(), err)
 		return
 	}
 


### PR DESCRIPTION
提供一种可行的方法解决 #48  

- 通过sync.Map 支持并发的map 对每个host管理一把锁，请求需要抢到锁后才能发起dns解析请求，否则只能等待并从cache中读，如果cache中没有则退回到备用dns
- 优化对hijack-dns的日志打印，默认不输出hijack dns信息