### PR TITLE
Remove RndImg check

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -73,16 +73,6 @@ func (c *EasyConnectClient) loginAuthAndPsw() error {
 	c.twfID = string(regexp.MustCompile(`<TwfID>(.*)</TwfID>`).FindSubmatch(buf.Bytes())[1])
 	log.Printf("TWFID: %s", c.twfID)
 
-	// Now we need to do authentication
-	rndImg := string(regexp.MustCompile(`<RndImg>(.*)</RndImg>`).FindSubmatch(buf.Bytes())[1])
-	if rndImg == "1" {
-		log.Print("Due to too many login failures, the server has activated risk control for this IP")
-		log.Print("Continuing to log in may cause this IP to be banned. The program has stopped the login process")
-		log.Print("You can wait a minute and try again")
-
-		return errors.New("too many login failures")
-	}
-
 	rsaKey := string(regexp.MustCompile(`<RSA_ENCRYPT_KEY>(.*)</RSA_ENCRYPT_KEY>`).FindSubmatch(buf.Bytes())[1])
 	log.Printf("RSA key: %s", rsaKey)
 


### PR DESCRIPTION
在 #8 中，经过讨论，进行了如下更改：登录时返回的字段中包括 <RndImg>1</RndImg>，说明之前登录失败的次数过多，之后再登录失败会被封禁 IP，因此阻止本次登录

目前看来，这一功能并无必要：

1. 在风控已经启动后，即使阻止这次登录，在之后短时间内的登录中还是需要输入图片验证码，而 zju-connect 并没有实现图片验证码登录。并且即使封禁 IP，也会在一段时间（可能不到 10 分钟）后解封。因此阻止登录的意义不大

2. 可能会造成非 ZJU RVPN 服务器的登录问题 #65 

考虑移除这一功能