### PR TITLE
Port/Protocol Level Rules

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -10,6 +10,20 @@ import (
 	"time"
 )
 
+type IPResource struct {
+	IPMin    net.IP
+	IPMax    net.IP
+	PortMin  int
+	PortMax  int
+	Protocol string
+}
+
+type DomainResource struct {
+	PortMin  int
+	PortMax  int
+	Protocol string
+}
+
 type EasyConnectClient struct {
 	server            string // Example: rvpn.zju.edu.cn:443. No protocol prefix
 	username          string
@@ -27,10 +41,11 @@ type EasyConnectClient struct {
 
 	lineList []string
 
-	ipResource     *netaddr.IPSet
-	domainResource map[string]bool
-	dnsResource    map[string]net.IP
-	dnsServer      string
+	ipResources     []IPResource
+	domainResources map[string]DomainResource
+	ipSet           *netaddr.IPSet
+	dnsResource     map[string]net.IP
+	dnsServer       string
 
 	ip        net.IP // Client IP
 	ipReverse []byte
@@ -62,20 +77,28 @@ func (c *EasyConnectClient) IP() (net.IP, error) {
 	return c.ip, nil
 }
 
-func (c *EasyConnectClient) IPResource() (*netaddr.IPSet, error) {
-	if c.ipResource == nil {
-		return nil, errors.New("IP resource not available")
+func (c *EasyConnectClient) IPSet() (*netaddr.IPSet, error) {
+	if c.ipSet == nil {
+		return nil, errors.New("IP set not available")
 	}
 
-	return c.ipResource, nil
+	return c.ipSet, nil
 }
 
-func (c *EasyConnectClient) DomainResource() (map[string]bool, error) {
-	if c.domainResource == nil {
-		return nil, errors.New("domain resource not available")
+func (c *EasyConnectClient) IPResources() ([]IPResource, error) {
+	if c.ipResources == nil {
+		return nil, errors.New("IP resources not available")
 	}
 
-	return c.domainResource, nil
+	return c.ipResources, nil
+}
+
+func (c *EasyConnectClient) DomainResources() (map[string]DomainResource, error) {
+	if c.domainResources == nil {
+		return nil, errors.New("domain resources not available")
+	}
+
+	return c.domainResources, nil
 }
 
 func (c *EasyConnectClient) DNSResource() (map[string]net.IP, error) {

--- a/client/parse.go
+++ b/client/parse.go
@@ -127,6 +127,7 @@ func (c *EasyConnectClient) parseResources(resources string) error {
 				isDomain := false
 				var ipMin net.IP
 				var ipMax net.IP
+				var hostPort string
 				if strings.Contains(host, "~") {
 					ipList := strings.Split(host, "~")
 					if len(ipList) != 2 {
@@ -152,7 +153,9 @@ func (c *EasyConnectClient) parseResources(resources string) error {
 						host = strings.Split(host, "//")[1]
 					}
 					host = strings.Split(host, "/")[0]
-
+					if strings.Contains(host, ":") {
+						host, hostPort, err = net.SplitHostPort(host)
+					}
 					ipMin = net.ParseIP(host)
 					if ipMin == nil {
 						isDomain = true
@@ -164,6 +167,10 @@ func (c *EasyConnectClient) parseResources(resources string) error {
 						log.DebugPrintf("Add domain: %s, Port range: %d ~ %d, [%s]", host, portMin, portMax, protocol)
 					} else {
 						ipMax = ipMin
+						if hostPortInt, err := strconv.Atoi(hostPort); hostPort != "" && err == nil {
+							portMin = hostPortInt
+							portMax = hostPortInt
+						}
 
 						ipSetBuilder.Add(netaddr.MustParseIP(host))
 						log.DebugPrintf("Add IP: %s, Port range: %d ~ %d, [%s]", host, portMin, portMax, protocol)

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,10 @@ go 1.24.1
 require github.com/refraction-networking/utls v1.6.7
 
 require (
-	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c
+	github.com/BurntSushi/toml v1.5.0
 	github.com/beevik/etree v1.5.0
 	github.com/cloverstd/tcping v0.1.1
 	github.com/cxz66666/sing-tun v0.0.0-20231028191617-2867d9374292
-	github.com/golang-infrastructure/go-domain-suffix-trie v0.0.2
 	github.com/miekg/dns v1.1.63
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pquerna/otp v1.4.0
@@ -21,7 +20,7 @@ require (
 	golang.org/x/sys v0.31.0
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 	golang.zx2c4.com/wireguard/windows v0.5.3
-	gvisor.dev/gvisor v0.0.0-20250314001526-eeca54973f8b
+	gvisor.dev/gvisor v0.0.0-20250317184159-a24f13b091dc
 	inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
-github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=
@@ -23,8 +23,6 @@ github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
-github.com/golang-infrastructure/go-domain-suffix-trie v0.0.2 h1:8AyA1jDDahI6moCH9xtmOlMS07OncQTK8INinJxB0tU=
-github.com/golang-infrastructure/go-domain-suffix-trie v0.0.2/go.mod h1:PA7neNAxdqgeAh3Ggyssa8uhJ2VUuKxft25tGdMSfjE=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
@@ -128,7 +126,7 @@ golang.zx2c4.com/wireguard/windows v0.5.3 h1:On6j2Rpn3OEMXqBq00QEDC7bWSZrPIHKIus
 golang.zx2c4.com/wireguard/windows v0.5.3/go.mod h1:9TEe8TJmtwyQebdFwAkEWOPr3prrtqm+REGFifP60hI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gvisor.dev/gvisor v0.0.0-20250314001526-eeca54973f8b h1:RZoMJ4FFNaRvHW+7oQiXwtEu2D7JZYdP5GCs2COvWKw=
-gvisor.dev/gvisor v0.0.0-20250314001526-eeca54973f8b/go.mod h1:5DMfjtclAbTIjbXqO1qCe2K5GKKxWz2JHvCChuTcJEM=
+gvisor.dev/gvisor v0.0.0-20250317184159-a24f13b091dc h1:J6cNomELwde1luDrL6hH2NeVEBIaAofaaC2Glwl0MsQ=
+gvisor.dev/gvisor v0.0.0-20250317184159-a24f13b091dc/go.mod h1:5DMfjtclAbTIjbXqO1qCe2K5GKKxWz2JHvCChuTcJEM=
 inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a h1:1XCVEdxrvL6c0TGOhecLuB7U9zYNdxZEjvOqJreKZiM=
 inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a/go.mod h1:e83i32mAQOW1LAqEIweALsuK2Uw4mhQadA5r7b0Wobo=

--- a/internal/hook_func/initial_func_darwin.go
+++ b/internal/hook_func/initial_func_darwin.go
@@ -1,12 +1,66 @@
 package hook_func
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"github.com/mythologyli/zju-connect/configs"
 	"os"
+	"os/exec"
 	"os/user"
+	"strings"
 )
+
+// get all services and skip element contains "*"
+func ListNetworkServices() ([]string, error) {
+	cmd := exec.Command("networksetup", "-listallnetworkservices")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(output), "\n")
+	var services []string
+	for _, line := range lines[1:] { // 跳过第一行标题
+		line = strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "*") {
+			services = append(services, line)
+		}
+	}
+	return services, nil
+}
+
+func SetDNSServer(service, dns string) error {
+	cmd := exec.Command("sudo", "networksetup", "-setdnsservers", service, dns)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	return cmd.Run()
+}
+
+func SetDNSServerWithHook(service, dns string) error {
+	// networksetup -setdnsservers "service name" DNS_IP
+	cmd := exec.Command("sudo", "networksetup", "-setdnsservers", service, dns)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	RegisterTerminalFunc("CleanDnsServer_"+service, func(ctx context.Context) error {
+		delCommand := exec.Command("sudo", "networksetup", "-setdnsservers", service, "Empty")
+		delErr := delCommand.Run()
+		if delErr != nil {
+			return delErr
+		}
+		return nil
+	})
+
+	return nil
+}
 
 func init() {
 	RegisterInitialFunc("clean resolver file", func(ctx context.Context, config configs.Config) error {
@@ -26,4 +80,18 @@ func init() {
 		return nil
 	})
 	RegisterInitialFunc("check bind port", checkBindPortLegal)
+	RegisterInitialFunc("set dns server", func(ctx context.Context, config configs.Config) error {
+		services, err := ListNetworkServices()
+		if err != nil {
+			return err
+		}
+
+		for _, service := range services {
+			if err := SetDNSServer(service, "Empty"); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
 }

--- a/main.go
+++ b/main.go
@@ -81,52 +81,102 @@ func main() {
 
 	log.Printf("EasyConnect client started")
 
-	ipResource, err := vpnClient.IPResource()
-	if err != nil && !conf.DisableMultiLine {
-		log.Println("No IP resource")
+	ipResources, err := vpnClient.IPResources()
+	if err != nil && !conf.DisableServerConfig {
+		log.Println("No IP resources")
 	}
 
-	domainResource, err := vpnClient.DomainResource()
-	if err != nil && !conf.DisableMultiLine {
-		log.Println("No domain resource")
+	ipSet, err := vpnClient.IPSet()
+	if err != nil && !conf.DisableServerConfig {
+		log.Println("No IP set")
+	}
+
+	domainResources, err := vpnClient.DomainResources()
+	if err != nil && !conf.DisableServerConfig {
+		log.Println("No domain resources")
 	}
 
 	dnsResource, err := vpnClient.DNSResource()
-	if err != nil && !conf.DisableMultiLine {
+	if err != nil && !conf.DisableServerConfig {
 		log.Println("No DNS resource")
 	}
 
 	if !conf.DisableZJUConfig {
-		if domainResource != nil {
-			domainResource["zju.edu.cn"] = true
+		if domainResources != nil {
+			domainResources["zju.edu.cn"] = client.DomainResource{
+				PortMin:  1,
+				PortMax:  65535,
+				Protocol: "all",
+			}
 		} else {
-			domainResource = map[string]bool{"zju.edu.cn": true}
+			domainResources = map[string]client.DomainResource{
+				"zju.edu.cn": {
+					PortMin:  1,
+					PortMax:  65535,
+					Protocol: "all",
+				},
+			}
+		}
+
+		if ipResources != nil {
+			ipResources = append(ipResources, client.IPResource{
+				IPMin:    net.ParseIP("10.0.0.0"),
+				IPMax:    net.ParseIP("10.255.255.255"),
+				PortMin:  1,
+				PortMax:  65535,
+				Protocol: "all",
+			})
+		} else {
+			ipResources = []client.IPResource{{
+				IPMin:    net.ParseIP("10.0.0.0"),
+				IPMax:    net.ParseIP("10.255.255.255"),
+				PortMin:  1,
+				PortMax:  65535,
+				Protocol: "all",
+			}}
 		}
 
 		ipSetBuilder := netaddr.IPSetBuilder{}
-		if ipResource != nil {
-			ipSetBuilder.AddSet(ipResource)
+		if ipSet != nil {
+			ipSetBuilder.AddSet(ipSet)
 		}
 		ipSetBuilder.AddPrefix(netaddr.MustParseIPPrefix("10.0.0.0/8"))
-		ipResource, _ = ipSetBuilder.IPSet()
+		ipSet, _ = ipSetBuilder.IPSet()
 	}
 
 	for _, customProxyDomain := range conf.CustomProxyDomain {
-		domainResource[customProxyDomain] = true
+		if domainResources != nil {
+			domainResources[customProxyDomain] = client.DomainResource{
+				PortMin:  1,
+				PortMax:  65535,
+				Protocol: "all",
+			}
+		} else {
+			domainResources = map[string]client.DomainResource{
+				customProxyDomain: {
+					PortMin:  1,
+					PortMax:  65535,
+					Protocol: "all",
+				},
+			}
+		}
 	}
 
 	var vpnStack stack.Stack
 	if conf.TUNMode {
-		vpnTUNStack, err := tun.NewStack(vpnClient, conf.DNSHijack)
+		vpnTUNStack, err := tun.NewStack(vpnClient, conf.DNSHijack, ipResources, domainResources)
 		if err != nil {
 			log.Fatalf("Tun stack setup error, make sure you are root user : %s", err)
 		}
 
-		if conf.AddRoute && ipResource != nil {
-			for _, prefix := range ipResource.Prefixes() {
+		if conf.AddRoute && ipSet != nil {
+			for _, prefix := range ipSet.Prefixes() {
 				log.Printf("Add route to %s", prefix.String())
 				_ = vpnTUNStack.AddRoute(prefix.String())
 			}
+		} else if !conf.AddRoute && !conf.DisableZJUConfig {
+			log.Println("Add route to 10.0.0.0/8")
+			_ = vpnTUNStack.AddRoute("10.0.0.0/8")
 		}
 
 		vpnStack = vpnTUNStack
@@ -155,7 +205,7 @@ func main() {
 		zjuDNSServer,
 		conf.SecondaryDNSServer,
 		conf.DNSTTL,
-		domainResource,
+		domainResources,
 		dnsResource,
 		useZJUDNS,
 	)
@@ -173,7 +223,7 @@ func main() {
 
 	go vpnStack.Run()
 
-	vpnDialer := dial.NewDialer(vpnStack, vpnResolver, ipResource, conf.ProxyAll, conf.DialDirectProxy)
+	vpnDialer := dial.NewDialer(vpnStack, vpnResolver, ipResources, conf.ProxyAll, conf.DialDirectProxy)
 
 	if conf.DNSServerBind != "" {
 		go service.ServeDNS(conf.DNSServerBind, localResolver)

--- a/main.go
+++ b/main.go
@@ -164,7 +164,7 @@ func main() {
 
 	var vpnStack stack.Stack
 	if conf.TUNMode {
-		vpnTUNStack, err := tun.NewStack(vpnClient, conf.DNSHijack, ipResources, domainResources)
+		vpnTUNStack, err := tun.NewStack(vpnClient, conf.DNSHijack, ipResources)
 		if err != nil {
 			log.Fatalf("Tun stack setup error, make sure you are root user : %s", err)
 		}

--- a/main_tun.go
+++ b/main_tun.go
@@ -160,7 +160,7 @@ func main() {
 		}
 	}
 
-	vpnStack, err := tun.NewStack(vpnClient, conf.DNSHijack, ipResources, domainResources)
+	vpnStack, err := tun.NewStack(vpnClient, conf.DNSHijack, ipResources)
 	if err != nil {
 		log.Fatalf("Tun stack setup error, make sure you are root user : %s", err)
 	}

--- a/main_tun.go
+++ b/main_tun.go
@@ -79,50 +79,100 @@ func main() {
 
 	log.Printf("EasyConnect client started")
 
-	ipResource, err := vpnClient.IPResource()
-	if err != nil && !conf.DisableMultiLine {
-		log.Println("No IP resource")
+	ipResources, err := vpnClient.IPResources()
+	if err != nil && !conf.DisableServerConfig {
+		log.Println("No IP resources")
 	}
 
-	domainResource, err := vpnClient.DomainResource()
-	if err != nil && !conf.DisableMultiLine {
-		log.Println("No domain resource")
+	ipSet, err := vpnClient.IPSet()
+	if err != nil && !conf.DisableServerConfig {
+		log.Println("No IP set")
+	}
+
+	domainResources, err := vpnClient.DomainResources()
+	if err != nil && !conf.DisableServerConfig {
+		log.Println("No domain resources")
 	}
 
 	dnsResource, err := vpnClient.DNSResource()
-	if err != nil && !conf.DisableMultiLine {
+	if err != nil && !conf.DisableServerConfig {
 		log.Println("No DNS resource")
 	}
 
 	if !conf.DisableZJUConfig {
-		if domainResource != nil {
-			domainResource["zju.edu.cn"] = true
+		if domainResources != nil {
+			domainResources["zju.edu.cn"] = client.DomainResource{
+				PortMin:  1,
+				PortMax:  65535,
+				Protocol: "all",
+			}
 		} else {
-			domainResource = map[string]bool{"zju.edu.cn": true}
+			domainResources = map[string]client.DomainResource{
+				"zju.edu.cn": {
+					PortMin:  1,
+					PortMax:  65535,
+					Protocol: "all",
+				},
+			}
+		}
+
+		if ipResources != nil {
+			ipResources = append(ipResources, client.IPResource{
+				IPMin:    net.ParseIP("10.0.0.0"),
+				IPMax:    net.ParseIP("10.255.255.255"),
+				PortMin:  1,
+				PortMax:  65535,
+				Protocol: "all",
+			})
+		} else {
+			ipResources = []client.IPResource{{
+				IPMin:    net.ParseIP("10.0.0.0"),
+				IPMax:    net.ParseIP("10.255.255.255"),
+				PortMin:  1,
+				PortMax:  65535,
+				Protocol: "all",
+			}}
 		}
 
 		ipSetBuilder := netaddr.IPSetBuilder{}
-		if ipResource != nil {
-			ipSetBuilder.AddSet(ipResource)
+		if ipSet != nil {
+			ipSetBuilder.AddSet(ipSet)
 		}
 		ipSetBuilder.AddPrefix(netaddr.MustParseIPPrefix("10.0.0.0/8"))
-		ipResource, _ = ipSetBuilder.IPSet()
+		ipSet, _ = ipSetBuilder.IPSet()
 	}
 
 	for _, customProxyDomain := range conf.CustomProxyDomain {
-		domainResource[customProxyDomain] = true
+		if domainResources != nil {
+			domainResources[customProxyDomain] = client.DomainResource{
+				PortMin:  1,
+				PortMax:  65535,
+				Protocol: "all",
+			}
+		} else {
+			domainResources = map[string]client.DomainResource{
+				customProxyDomain: {
+					PortMin:  1,
+					PortMax:  65535,
+					Protocol: "all",
+				},
+			}
+		}
 	}
 
-	vpnStack, err := tun.NewStack(vpnClient, conf.DNSHijack)
+	vpnStack, err := tun.NewStack(vpnClient, conf.DNSHijack, ipResources, domainResources)
 	if err != nil {
 		log.Fatalf("Tun stack setup error, make sure you are root user : %s", err)
 	}
 
-	if conf.AddRoute && ipResource != nil {
-		for _, prefix := range ipResource.Prefixes() {
+	if conf.AddRoute && ipSet != nil {
+		for _, prefix := range ipSet.Prefixes() {
 			log.Printf("Add route to %s", prefix.String())
 			_ = vpnStack.AddRoute(prefix.String())
 		}
+	} else if !conf.AddRoute && !conf.DisableZJUConfig {
+		log.Println("Add route to 10.0.0.0/8")
+		_ = vpnStack.AddRoute("10.0.0.0/8")
 	}
 
 	useZJUDNS := !conf.DisableZJUDNS
@@ -143,7 +193,7 @@ func main() {
 		zjuDNSServer,
 		conf.SecondaryDNSServer,
 		conf.DNSTTL,
-		domainResource,
+		domainResources,
 		dnsResource,
 		useZJUDNS,
 	)
@@ -161,7 +211,7 @@ func main() {
 
 	go vpnStack.Run()
 
-	vpnDialer := dial.NewDialer(vpnStack, vpnResolver, ipResource, conf.ProxyAll, conf.DialDirectProxy)
+	vpnDialer := dial.NewDialer(vpnStack, vpnResolver, ipResources, conf.ProxyAll, conf.DialDirectProxy)
 
 	if conf.DNSServerBind != "" {
 		go service.ServeDNS(conf.DNSServerBind, localResolver)

--- a/resolve/resolver.go
+++ b/resolve/resolver.go
@@ -3,11 +3,12 @@ package resolve
 import (
 	"context"
 	"errors"
-	domainsuffixtrie "github.com/golang-infrastructure/go-domain-suffix-trie"
+	"github.com/mythologyli/zju-connect/client"
 	"github.com/mythologyli/zju-connect/log"
 	"github.com/mythologyli/zju-connect/stack"
 	"github.com/patrickmn/go-cache"
 	"net"
+	"strings"
 	"sync"
 	"time"
 )
@@ -17,7 +18,7 @@ type Resolver struct {
 	remoteTCPResolver *net.Resolver
 	secondaryResolver *net.Resolver
 	ttl               uint64
-	domainResource    *domainsuffixtrie.DomainSuffixTrieNode[bool]
+	domainResources   map[string]client.DomainResource
 	dnsResource       map[string]net.IP
 	useRemoteDNS      bool
 
@@ -33,33 +34,33 @@ type Resolver struct {
 	concurResolveLock sync.Map
 }
 
-// Resolve ip address. If the host should be visited via VPN, this function set a USE_VPN value in context. If resolve success, this function set a RESOLVE_HOST value in context.
+type contextKey string
+
+var (
+	ContextKeyResolveHost    = contextKey("RESOLVE_HOST")
+	ContextKeyDomainResource = contextKey("DOMAIN_RESOURCE")
+)
+
+// Resolve ip address. If the host could be visited via VPN, this function set a DOMAIN_RESOURCE value in context. If resolve success, this function set a RESOLVE_HOST value in context.
 func (r *Resolver) Resolve(ctx context.Context, host string) (resCtx context.Context, resIP net.IP, resErr error) {
 	defer func() {
 		if resErr == nil {
-			resCtx = context.WithValue(resCtx, "RESOLVE_HOST", host)
+			resCtx = context.WithValue(resCtx, ContextKeyResolveHost, host)
 		}
 	}()
-	var useVPN = false
-	if r.domainResource != nil {
-		if r.domainResource.FindMatchDomainSuffixPayload(host) {
-			useVPN = true
+	if r.domainResources != nil {
+		for domain, resource := range r.domainResources {
+			if strings.HasSuffix(host, domain) {
+				ctx = context.WithValue(ctx, ContextKeyDomainResource, resource)
+				log.DebugPrintf("Domain resource found: %s", domain)
+				break
+			}
 		}
 	}
-
-	ctx = context.WithValue(ctx, "USE_VPN", useVPN)
 
 	if cachedIP, found := r.getDNSCache(host); found {
 		log.Printf("%s -> %s", host, cachedIP.String())
 		return ctx, cachedIP, nil
-	}
-
-	if r.dnsResource != nil {
-		if ip, found := r.dnsResource[host]; found {
-			ctx = context.WithValue(ctx, "USE_VPN", true)
-			log.Printf("%s -> %s", host, ip.String())
-			return ctx, ip, nil
-		}
 	}
 
 	if r.useRemoteDNS {
@@ -162,11 +163,11 @@ func (r *Resolver) CleanCache(duration time.Duration) {
 	}
 }
 
-func NewResolver(stack stack.Stack, remoteDNSServer, secondaryDNSServer string, ttl uint64, domainResource map[string]bool, dnsResource map[string]net.IP, useRemoteDNS bool) *Resolver {
-	domainSuffixTree := domainsuffixtrie.NewDomainSuffixTrie[bool]()
-	for domain := range domainResource {
-		_ = domainSuffixTree.AddDomainSuffix(domain, true)
-	}
+func NewResolver(stack stack.Stack, remoteDNSServer, secondaryDNSServer string, ttl uint64, domainResources map[string]client.DomainResource, dnsResource map[string]net.IP, useRemoteDNS bool) *Resolver {
+	//domainSuffixTree := domainsuffixtrie.NewDomainSuffixTrie[bool]()
+	//for domain := range domainResource {
+	//	_ = domainSuffixTree.AddDomainSuffix(domain, true)
+	//}
 
 	resolver := &Resolver{
 		remoteUDPResolver: &net.Resolver{
@@ -187,11 +188,11 @@ func NewResolver(stack stack.Stack, remoteDNSServer, secondaryDNSServer string, 
 				})
 			},
 		},
-		ttl:            ttl,
-		domainResource: domainSuffixTree,
-		dnsResource:    dnsResource,
-		dnsCache:       cache.New(time.Duration(ttl)*time.Second, time.Duration(ttl)*2*time.Second),
-		useRemoteDNS:   useRemoteDNS,
+		ttl:             ttl,
+		domainResources: domainResources,
+		dnsResource:     dnsResource,
+		dnsCache:        cache.New(time.Duration(ttl)*time.Second, time.Duration(ttl)*2*time.Second),
+		useRemoteDNS:    useRemoteDNS,
 	}
 
 	if secondaryDNSServer != "" {

--- a/resolve/resolver.go
+++ b/resolve/resolver.go
@@ -63,6 +63,13 @@ func (r *Resolver) Resolve(ctx context.Context, host string) (resCtx context.Con
 		return ctx, cachedIP, nil
 	}
 
+	if r.dnsResource != nil {
+		if ip, found := r.dnsResource[host]; found {
+			log.Printf("%s -> %s", host, ip.String())
+			return ctx, ip, nil
+		}
+	}
+
 	if r.useRemoteDNS {
 		r.tcpLock.RLock()
 		useTCP := r.useTCP

--- a/stack/tun/dial_darwin.go
+++ b/stack/tun/dial_darwin.go
@@ -1,21 +1,21 @@
 package tun
 
 import (
+	"inet.af/netaddr"
 	"net"
-	"net/netip"
 )
 
-var zjuRouterPrefix = netip.MustParsePrefix("10.0.0.0/8")
-
 func (s *Stack) DialTCP(addr *net.TCPAddr) (net.Conn, error) {
-	if zjuRouterPrefix.Contains(addr.AddrPort().Addr()) {
+	prefix, ok := netaddr.FromStdIP(addr.IP)
+	if ok && s.endpoint.ipSet.Contains(prefix) {
 		return s.endpoint.tcpDialer.Dial("tcp4", addr.String())
 	}
 	return net.DialTCP("tcp4", nil, addr)
 }
 
 func (s *Stack) DialUDP(addr *net.UDPAddr) (net.Conn, error) {
-	if zjuRouterPrefix.Contains(addr.AddrPort().Addr()) {
+	prefix, ok := netaddr.FromStdIP(addr.IP)
+	if ok && s.endpoint.ipSet.Contains(prefix) {
 		return s.endpoint.udpDialer.Dial("udp4", addr.String())
 	}
 	return net.DialUDP("udp4", nil, addr)

--- a/stack/tun/stack_darwin.go
+++ b/stack/tun/stack_darwin.go
@@ -106,8 +106,9 @@ func NewStack(easyConnectClient *client.EasyConnectClient, dnsHijack bool, ipRes
 		Inet4Address: []netip.Prefix{
 			ipPrefix,
 		},
-		AutoRoute:  true,
-		TableIndex: 1897,
+		// Inet4Address and Inet4RouteAddress must be set concurrently if we want to enable AutoRoute
+		// otherwise the sing-tun will add weird router
+		AutoRoute: false,
 	}
 
 	ifce, err := tun.New(tunOptions)

--- a/stack/tun/stack_linux.go
+++ b/stack/tun/stack_linux.go
@@ -54,7 +54,7 @@ func (s *Stack) AddRoute(target string) error {
 	return nil
 }
 
-func NewStack(easyConnectClient *client.EasyConnectClient, dnsHijack bool, ipResources []client.IPResource, domainResources map[string]client.DomainResource) (*Stack, error) {
+func NewStack(easyConnectClient *client.EasyConnectClient, dnsHijack bool, ipResources []client.IPResource) (*Stack, error) {
 	var err error
 	s := &Stack{}
 	s.ipResources = ipResources

--- a/stack/tun/stack_linux.go
+++ b/stack/tun/stack_linux.go
@@ -54,9 +54,10 @@ func (s *Stack) AddRoute(target string) error {
 	return nil
 }
 
-func NewStack(easyConnectClient *client.EasyConnectClient, dnsHijack bool) (*Stack, error) {
+func NewStack(easyConnectClient *client.EasyConnectClient, dnsHijack bool, ipResources []client.IPResource, domainResources map[string]client.DomainResource) (*Stack, error) {
 	var err error
 	s := &Stack{}
+	s.ipResources = ipResources
 	s.endpoint = &Endpoint{
 		easyConnectClient: easyConnectClient,
 	}
@@ -65,7 +66,7 @@ func NewStack(easyConnectClient *client.EasyConnectClient, dnsHijack bool) (*Sta
 	if err != nil {
 		return nil, err
 	}
-	ipPrefix, _ := netip.ParsePrefix(s.endpoint.ip.String() + "/8")
+	ipPrefix, _ := netip.ParsePrefix(s.endpoint.ip.String() + "/32")
 	tunName := "ZJU-Connect"
 	tunName = tun.CalculateInterfaceName(tunName)
 

--- a/stack/tun/stack_windows.go
+++ b/stack/tun/stack_windows.go
@@ -77,7 +77,7 @@ func (s *Stack) AddRoute(target string) error {
 	return nil
 }
 
-func NewStack(easyConnectClient *client.EasyConnectClient, dnsHijack bool, ipResources []client.IPResource, domainResources map[string]client.DomainResource) (*Stack, error) {
+func NewStack(easyConnectClient *client.EasyConnectClient, dnsHijack bool, ipResources []client.IPResource) (*Stack, error) {
 	s := &Stack{}
 	s.ipResources = ipResources
 

--- a/stack/tun/stack_windows.go
+++ b/stack/tun/stack_windows.go
@@ -77,8 +77,9 @@ func (s *Stack) AddRoute(target string) error {
 	return nil
 }
 
-func NewStack(easyConnectClient *client.EasyConnectClient, dnsHijack bool) (*Stack, error) {
+func NewStack(easyConnectClient *client.EasyConnectClient, dnsHijack bool, ipResources []client.IPResource, domainResources map[string]client.DomainResource) (*Stack, error) {
 	s := &Stack{}
+	s.ipResources = ipResources
 
 	guid, err := windows.GUIDFromString(guid)
 	if err != nil {
@@ -105,7 +106,7 @@ func NewStack(easyConnectClient *client.EasyConnectClient, dnsHijack bool) (*Sta
 		return nil, err
 	}
 
-	prefix, err := netip.ParsePrefix(s.endpoint.ip.String() + "/8")
+	prefix, err := netip.ParsePrefix(s.endpoint.ip.String() + "/32")
 	if err != nil {
 		log.Printf("Parse prefix failed: %v", err) // Fail to set TUN IP is not a fatal problem, so we don't return an error
 	}


### PR DESCRIPTION
由于部分服务端（主要为 7.6.6 以上）对流量的校验很严格 (#65 #70)，一旦进行了非法访问服务端会断开连接。ZJU 的服务端由于版本较老，暂未出现此问题，不过如果未来升级服务端版本也可能出现这种现象。

此 PR 添加了基于服务端下发资源的端口/协议级别的分流。主要修改有这几处：

1. 解析服务端下发资源时精确到端口和协议。资源的格式如下：

    ```
    <Rc app_path="" attr="0" auth_sp_id="0" authorization="1" enable_disguise="0" host="https://ieeexplore.ieee.org" id="274" name="ieeexplore" note="" port="0" proto="0" rc_grp_id="8" rc_logo="05_font_face_xe60d.png" selectid="-1" svc="WebApp:HTTPS" type="0"/>
    <Rc app_path="" attr="0" auth_sp_id="0" authorization="1" enable_disguise="0" host="https://bb.xxx.edu.cn" id="281" name="bb.xxx.edu.cn" note="" port="443~443" proto="0" rc_grp_id="4" rc_logo="05_font_face_xe60d.png" selectid="-1" svc="HTTPS" type="1"/>
    <Rc app_path="" attr="0" auth_sp_id="0" authorization="1" enable_disguise="0" host="219.x.x.x.;219.x.x.x" id="307" name="物业" note="" port="80~80;443~443" proto="0" rc_grp_id="6" rc_logo="05_font_face_xe60d.png" selectid="-1" svc="Other" type="2"/>
    ```
    type 0 是类似 webvpn 的访问方法，暂未实现，目前只对 type 1（TCP 应用） 和 type 2（L3VPN 应用） 进行解析。每条资源中给出了 host（可能为单个 IP 地址，或 StartIP ~ EndIP，或域名，或 URL），端口号（StartPort ~ EndPort，如果只有一个端口也是此格式），协议类型（0 为 TCP，1 为 UDP，2 为 ICMP，-1 猜测为全部）。这里粗略地将资源分为 IP 资源和域名资源。

2. DNS 解析时，如果发现匹配到域名资源，则将资源的具体信息（端口范围、协议类型）保存到上下文中（因为此时并不能获得请求的端口和类型，无法判断是否走 VPN）。在 DialIPPort 函数中结合上下文和端口、协议进行判断。

3. gVisor 栈未做修改，因为 gVisor 栈上的流量一定来自于 Dial 函数，已经进行了完善地分流。TUN 栈进行了修改：

    ```golang
    func (s *Stack) processIPV4(packet zctcpip.IPv4Packet) error {
	    protocol := ""
	    port := -1
	    switch packet.Protocol() {
	    case zctcpip.TCP:
		    protocol = "tcp"
		    port = int(zctcpip.TCPPacket(packet.Payload()).DestinationPort())
	    case zctcpip.UDP:
		    udpPacket := zctcpip.UDPPacket(packet.Payload())
		    if s.shouldHijackUDPDns(packet, udpPacket) {
			    newPacket := make(zctcpip.IPv4Packet, len(packet))
			    copy(newPacket, packet)
			    newUdpPacket := zctcpip.UDPPacket(newPacket.Payload())
			    // need to be non-blocking
			    go s.doHijackUDPDns(newPacket, newUdpPacket)
			    return nil
		    }
    
		    protocol = "udp"
		    port = int(zctcpip.UDPPacket(packet.Payload()).DestinationPort())
	    case zctcpip.ICMP:
		    protocol = "icmp"
	    default:
		    return fmt.Errorf("protocol %d not supported, skip", packet.Protocol())
	    }
    
	    for _, resource := range s.ipResources {
		    if bytes.Compare(packet.DestinationIP(), resource.IPMin) >= 0 && bytes.Compare(packet.DestinationIP(), resource.IPMax) <= 0 {
			    if resource.Protocol == protocol || resource.Protocol == "all" {
				    if protocol == "icmp" {
					    return s.processIPV4ICMP(packet, packet.Payload())
				    }
    
				    if resource.PortMin <= port && port <= resource.PortMax {
					    if protocol == "tcp" {
						    return s.processIPV4TCP(packet, packet.Payload())
					    } else {
						    return s.processIPV4UDP(packet, packet.Payload())
					    }
				    }
			    }
		    }
	    }
    
	    if port != -1 {
		    return fmt.Errorf("no VPN resources found for %s:%d, [%s], skip", packet.DestinationIP(), port, protocol)
	    } else {
		    return fmt.Errorf("no VPN resources found for %s, [%s], skip", packet.DestinationIP(), protocol)
	    }
    }
    ```

    此处将 DNS 劫持的逻辑前移，并添加了 IP、端口和协议的判断。一是因为路由规则不可能精确到端口和协议，高版本服务器即使只是访问了不能访问的端口也会断开连接。二是 TUN 上总有一些其他的流量（如 mDNS），无视路由，这部分流量也需要筛除。

4. 为了更好适配其他服务端，删除了一些 ZJU 独有的硬编码的内容（如 TUN 改为了 /32 等等），这些内容通过 ZJUConfig 参数选择性添加。还请 @cxz66666 帮忙看看会不会破坏了 darwin 等系统上的 TUN 功能。

