### PR TITLE
docs: update config example and docker docs for aTrust protocol

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -1,4 +1,4 @@
-protocol = "easyconnect" # "easyconnect" or "anyconnect"
+protocol = "easyconnect" # "easyconnect" or "atrust"
 server_address = "rvpn.zju.edu.cn"
 server_port = 443
 username = "username"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,8 +7,6 @@ $ docker run -d --name zju-connect -v $PWD/config.toml:/home/nonroot/config.toml
 也可以使用 Docker Compose。创建 `docker-compose.yml` 文件，内容如下：
 
 ```yaml
-version: '3'
-
 services:
    zju-connect:
       image: mythologyli/zju-connect
@@ -43,5 +41,69 @@ configs:
 并在同目录下运行
 
 ```zsh
-$ docker compose up -d
+docker compose up -d
 ```
+
+### aTrust 协议登录和数据持久化
+
+aTrust 协议客户端需要在容器内持久化登录凭据（`client_data.json`），可参考以下示例配置，将凭据文件保存在 Docker 卷中：
+
+```
+services:
+   zju-connect:
+      container_name: zju-connect
+      image: mythologyli/zju-connect
+      restart: unless-stopped
+      ports:
+         - 1080:1080
+         - 1081:1081
+      configs:
+         - source: zju-connect-config
+           target: /home/nonroot/config.toml
+      volumes:
+         - zju-connect-data:/home/nonroot/data
+configs:
+   zju-connect-config:
+      content: |
+         username = ""
+         password = ""
+         client_data_file = "/home/nonroot/data/client_data.json"
+         # other configs ...
+volumes:
+   zju-connect-data:
+```
+
+使用 aTrust 协议初次登录时需要人工验证，应当使用 `network_mode: host` 和交互模式临时运行：
+
+```zsh
+docker compose run --rm -it zju-connect
+```
+
+以下以 ZJU 服务端为例：
+
+**1. 图形验证码**
+
+程序会启动一个临时 HTTP 服务器显示验证码，端口号由系统随机分配。请从日志中查看实际地址：
+
+```
+2026/03/25 09:10:46 Captcha server started at http://127.0.0.1:40855
+2026/03/25 09:10:46 Failed to open browser: exec: "xdg-open": executable file not found in $PATH. Please visit: http://127.0.0.1:40855
+```
+
+访问日志中显示的地址完成图形验证码验证后，程序会提示输入短信验证码：
+
+**2. 短信验证码**
+
+```
+2026/03/25 09:10:57 SMS message sent successfully: 验证码已发送到您的手机：***, 请查收！
+zju-connect-1  | 2026/03/25 09:11:50 Please enter the SMS verification code:
+```
+
+出现上述提示后，请输入收到的短信验证码并回车。登录成功后会显示如下日志：
+
+```
+2026/03/25 09:12:12 Client data saved to /home/nonroot/data/client_data.json
+2026/03/25 09:12:12 VPN client started
+```
+
+完成登录后按 `Ctrl+C` 退出容器，之后就可以使用 `docker compose up -d` 正常启动了，登录状态会被持久化在 Docker 卷中，无需重复验证。

--- a/docs/docker_en.md
+++ b/docs/docker_en.md
@@ -7,8 +7,6 @@ docker run -d --name zju-connect -v $PWD/config.toml:/home/nonroot/config.toml -
 You can also use Docker Compose. Create `docker-compose.yml` file with the following content:
 
 ```yaml
-version: '3'
-
 services:
    zju-connect:
       image: mythologyli/zju-connect
@@ -45,3 +43,65 @@ And run the following command in the same directory:
 ```shell
 docker compose up -d
 ```
+
+### aTrust Protocol Login and Data Persistence
+
+The aTrust protocol client needs to persist login credentials (`client_data.json`) inside the container. The following example saves credentials to a Docker volume:
+
+```yaml
+services:
+   zju-connect:
+      container_name: zju-connect
+      image: mythologyli/zju-connect
+      restart: unless-stopped
+      ports:
+         - 1080:1080
+         - 1081:1081
+      configs:
+         - source: zju-connect-config
+           target: /home/nonroot/config.toml
+      volumes:
+         - zju-connect-data:/home/nonroot/data
+configs:
+   zju-connect-config:
+      content: |
+         username = ""
+         password = ""
+         client_data_file = "/home/nonroot/data/client_data.json"
+         # other configs ...
+volumes:
+   zju-connect-data:
+```
+
+When first logging in with the aTrust protocol, human verification is required. Use `network_mode: host` and run in interactive mode temporarily:
+
+```shell
+docker compose run --rm -it zju-connect
+```
+
+**1. Graphical Captcha**
+
+The program starts a temporary HTTP server to display the captcha. The port is randomly assigned by the system. Check the logs for the actual address:
+
+```
+2026/03/25 09:10:46 Captcha server started at http://127.0.0.1:40855
+2026/03/25 09:10:46 Failed to open browser: exec: "xdg-open": executable file not found in $PATH. Please visit: http://127.0.0.1:40855
+```
+
+After completing the captcha, the program will prompt for SMS verification:
+
+**2. SMS Verification Code**
+
+```
+2026/03/25 09:10:57 SMS message sent successfully: 验证码已发送到您的手机：***, 请查收！
+zju-connect-1  | 2026/03/25 09:11:50 Please enter the SMS verification code:
+```
+
+Enter the SMS code from your phone and press Enter. Upon successful login, you will see:
+
+```
+2026/03/25 09:12:12 Client data saved to /home/nonroot/data/client_data.json
+2026/03/25 09:12:12 VPN client started
+```
+
+After successful login, press `Ctrl+C` to exit the container. You can then use `docker compose up -d` normally. The login state is persisted in the Docker volume and no further verification is needed.


### PR DESCRIPTION
- Fix protocol option in config.toml.example: "anyconnect" → "atrust"
- Remove obsolete version top-level element from docker-compose.yml examples (see https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete)
- Add aTrust protocol login and data persistence documentation