### PR TITLE
feat: periodic /por/update_session.csp session keepalive

### DIFF
--- a/client/easyconnect/client.go
+++ b/client/easyconnect/client.go
@@ -187,5 +187,22 @@ func (c *Client) Setup(graphCodeFile string) error {
 		return err
 	}
 
+	// Periodic session keepalive. Without this, sangfor servers with strict
+	// idle policies (observed at HUST) close the session as idle, which
+	// surfaces as "broken pipe" + "unexpected handshake reply" panics in
+	// the L3 tunnel layer. The official EasyConnect client calls
+	// /por/update_session.csp; we mirror that.
+	go c.sessionKeepAliveLoop()
+
 	return nil
+}
+
+func (c *Client) sessionKeepAliveLoop() {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		if err := c.requestUpdateSession(); err != nil {
+			log.Printf("update_session keepalive failed: %v", err)
+		}
+	}
 }

--- a/client/easyconnect/request.go
+++ b/client/easyconnect/request.go
@@ -464,6 +464,43 @@ func (c *Client) requestConfig() (string, error) {
 	return buf.String(), nil
 }
 
+// requestUpdateSession pings /por/update_session.csp to keep the server-side
+// session alive. The official EasyConnect client calls this periodically;
+// without it, sangfor servers with strict idle policies (e.g. HUST) close
+// the session, which the tunnel layer surfaces as a "broken pipe" →
+// "unexpected handshake reply" kick cascade.
+func (c *Client) requestUpdateSession() error {
+	addr := "https://" + c.server + "/por/update_session.csp?twfid=" + c.twfID + "&apiversion=1"
+
+	req, err := http.NewRequest("GET", addr, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Cookie", "TWFID="+c.twfID)
+	req.Header.Set("User-Agent", "EasyConnect_Linux_Ubuntu")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	// Successful body looks like:
+	//   <Auth><Message>success</Message><ErrorCode>1</ErrorCode><TwfID>...</TwfID></Auth>
+	if !bytes.Contains(buf.Bytes(), []byte("success")) {
+		return errors.New("update_session: unexpected reply: " + buf.String())
+	}
+	return nil
+}
+
 func (c *Client) requestResources() (string, error) {
 	addr := "https://" + c.server + "/por/rclist.csp"
 	log.Printf("Request: %s", addr)


### PR DESCRIPTION
## Summary

Add a periodic ping to `/por/update_session.csp` after `Setup()` completes, to keep the server-side session alive on sangfor SSL VPN deployments with strict idle timeout policies.

## Background

Some sangfor deployments close the session if no keepalive is received, surfacing client-side as a `broken pipe` → `unexpected handshake reply` cascade in the L3 tunnel layer, ultimately panicking at `stack/gvisor/stack.go:105`.

mitmproxy capture of the official EasyConnect Linux client (against HUST's `vpn.hust.edu.cn`) shows it periodically issues:

```
GET /por/update_session.csp?twfid=<twfid>&apiversion=1
User-Agent: EasyConnect_Linux_Ubuntu
Cookie: TWFID=<twfid>; ...
```

The server replies:

```xml
<Auth>
  <Message><![CDATA[success]]></Message>
  <ErrorCode>1</ErrorCode>
  <TwfID>...</TwfID>
</Auth>
```

zju-connect doesn't currently call this endpoint, so on strict deployments the session is closed by the server within minutes.

## Change

- New `requestUpdateSession()` in `client/easyconnect/request.go`
- New `sessionKeepAliveLoop()` goroutine in `client/easyconnect/client.go`
- Started from `Setup()` after `requestIP()` succeeds
- 60s interval (conservative — the actual server idle threshold is unknown)

## Compatibility

- Endpoint is sangfor-standard, so calling it is harmless on deployments without strict idle timeouts (e.g. ZJU, where this issue has not been observed)
- Necessary on deployments that do close idle sessions (HUST, where it deterministically reproduces the panic)

## Testing

Tested at HUST: with the patch applied, sessions that previously panicked after a few minutes of browser activity stay alive indefinitely.

Reproducer for the upstream issue (without this patch):

1. Connect via zju-connect to HUST VPN
2. Open a HUST internal SPA in browser (via mihomo+SOCKS5 to zju-connect)
3. Wait a few minutes
4. Observe `unexpected handshake reply` panic
