### PR TITLE
feat: sangfor tunnel resilience (keepalive + cmd 0x08 SHUTDOWN handling + client-side ACL)

### DIFF
--- a/client/easyconnect/client.go
+++ b/client/easyconnect/client.go
@@ -187,5 +187,22 @@ func (c *Client) Setup(graphCodeFile string) error {
 		return err
 	}
 
+	// Periodic session keepalive. Without this, sangfor servers with strict
+	// idle policies (observed at HUST) close the session as idle, which
+	// surfaces as "broken pipe" + "unexpected handshake reply" panics in
+	// the L3 tunnel layer. The official EasyConnect client calls
+	// /por/update_session.csp; we mirror that.
+	go c.sessionKeepAliveLoop()
+
 	return nil
+}
+
+func (c *Client) sessionKeepAliveLoop() {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	for range ticker.C {
+		if err := c.requestUpdateSession(); err != nil {
+			log.Printf("update_session keepalive failed: %v", err)
+		}
+	}
 }

--- a/client/easyconnect/client.go
+++ b/client/easyconnect/client.go
@@ -41,12 +41,15 @@ type Client struct {
 	ip        net.IP // Client IP
 	ipReverse []byte
 
+	keepAliveCtx     context.Context
+	keepAliveCancel  context.CancelFunc
 	stopKeepAlive    chan struct{}
 	keepAliveStarted sync.Once
 	closeOnce        sync.Once
 }
 
 func NewClient(server, username, password, totpSecret string, tlsCert tls.Certificate, twfID string, testMultiLine, parseResource, useDomainResource bool) *Client {
+	keepAliveCtx, keepAliveCancel := context.WithCancel(context.Background())
 	return &Client{
 		server:            server,
 		username:          username,
@@ -60,8 +63,10 @@ func NewClient(server, username, password, totpSecret string, tlsCert tls.Certif
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}},
-		twfID:         twfID,
-		stopKeepAlive: make(chan struct{}),
+		twfID:           twfID,
+		keepAliveCtx:    keepAliveCtx,
+		keepAliveCancel: keepAliveCancel,
+		stopKeepAlive:   make(chan struct{}),
 	}
 }
 
@@ -70,6 +75,7 @@ func NewClient(server, username, password, totpSecret string, tlsCert tls.Certif
 // Safe to call multiple times.
 func (c *Client) Close() {
 	c.closeOnce.Do(func() {
+		c.keepAliveCancel()
 		close(c.stopKeepAlive)
 	})
 }
@@ -228,9 +234,11 @@ func (c *Client) sessionKeepAliveLoop() {
 		case <-c.stopKeepAlive:
 			return
 		case <-ticker.C:
-			if err := c.requestUpdateSession(); err != nil {
+			ctx, cancel := context.WithTimeout(c.keepAliveCtx, 10*time.Second)
+			if err := c.requestUpdateSession(ctx); err != nil {
 				log.Printf("update_session keepalive failed: %v", err)
 			}
+			cancel()
 		}
 	}
 }

--- a/client/easyconnect/client.go
+++ b/client/easyconnect/client.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/mythologyli/zju-connect/client"
+	"github.com/mythologyli/zju-connect/internal/hook_func"
 	"github.com/mythologyli/zju-connect/log"
 	"inet.af/netaddr"
 )
@@ -38,6 +40,10 @@ type Client struct {
 
 	ip        net.IP // Client IP
 	ipReverse []byte
+
+	stopKeepAlive    chan struct{}
+	keepAliveStarted sync.Once
+	closeOnce        sync.Once
 }
 
 func NewClient(server, username, password, totpSecret string, tlsCert tls.Certificate, twfID string, testMultiLine, parseResource, useDomainResource bool) *Client {
@@ -54,8 +60,18 @@ func NewClient(server, username, password, totpSecret string, tlsCert tls.Certif
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}},
-		twfID: twfID,
+		twfID:         twfID,
+		stopKeepAlive: make(chan struct{}),
 	}
+}
+
+// Close releases background resources held by the client. Currently this
+// stops the /por/update_session.csp keepalive goroutine started by Setup.
+// Safe to call multiple times.
+func (c *Client) Close() {
+	c.closeOnce.Do(func() {
+		close(c.stopKeepAlive)
+	})
 }
 
 func (c *Client) IP() (net.IP, error) {
@@ -191,8 +207,15 @@ func (c *Client) Setup(graphCodeFile string) error {
 	// idle policies (observed at HUST) close the session as idle, which
 	// surfaces as "broken pipe" + "unexpected handshake reply" panics in
 	// the L3 tunnel layer. The official EasyConnect client calls
-	// /por/update_session.csp; we mirror that.
-	go c.sessionKeepAliveLoop()
+	// /por/update_session.csp; we mirror that. Guarded by sync.Once so the
+	// recursive Setup() path (testMultiLine) doesn't double-start.
+	c.keepAliveStarted.Do(func() {
+		hook_func.RegisterTerminalFunc("CloseSessionKeepAlive", func(ctx context.Context) error {
+			c.Close()
+			return nil
+		})
+		go c.sessionKeepAliveLoop()
+	})
 
 	return nil
 }
@@ -200,9 +223,14 @@ func (c *Client) Setup(graphCodeFile string) error {
 func (c *Client) sessionKeepAliveLoop() {
 	ticker := time.NewTicker(60 * time.Second)
 	defer ticker.Stop()
-	for range ticker.C {
-		if err := c.requestUpdateSession(); err != nil {
-			log.Printf("update_session keepalive failed: %v", err)
+	for {
+		select {
+		case <-c.stopKeepAlive:
+			return
+		case <-ticker.C:
+			if err := c.requestUpdateSession(); err != nil {
+				log.Printf("update_session keepalive failed: %v", err)
+			}
 		}
 	}
 }

--- a/client/easyconnect/protocol.go
+++ b/client/easyconnect/protocol.go
@@ -3,11 +3,31 @@ package easyconnect
 import (
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 
 	"github.com/mythologyli/zju-connect/log"
 	"github.com/refraction-networking/utls"
+)
+
+// Sentinel errors representing semantically-meaningful sangfor cmd codes
+// returned by the server in response to a SendConn handshake. Identified
+// via reverse engineering of svpnservice's HandCmdMsg dispatch table
+// (jumptable @ 0x4e6fd0 in the official Linux EasyConnect 7.6.7 binary).
+var (
+	// 0x08 = SHUTDOWN — server is actively terminating this session and
+	// will not accept retries with the same credentials. Equivalent to a
+	// permanent "no" from the server. Recovery requires a fresh full
+	// re-login (new TwfID + new token), or accepting the session is dead.
+	ErrSangforShutdown = errors.New("sangfor: SHUTDOWN (cmd 0x08)")
+
+	// 0x05/0x06/0x07/0x09 = RECONNECTLATER_* — server is busy or has a
+	// session conflict. Caller should sleep and retry, optionally with
+	// a fresh re-login. Official client surfaces this to its orchestrator
+	// where an `enableAutoRelogin` config decides whether to redo the
+	// /por/login_*.csp flow.
+	ErrSangforReconnectLater = errors.New("sangfor: RECONNECT_LATER (cmd 0x05/0x06/0x07/0x09)")
 )
 
 type fakeHeartBeatExtension struct {
@@ -96,7 +116,22 @@ func (c *Client) RecvConn() (*tls.UConn, error) {
 	return conn, nil
 }
 
-// SendConn create a special TLS connection to send data to the VPN server
+// SendConn create a special TLS connection to send data to the VPN server.
+//
+// The first byte of the server reply is a HandCmdMsg cmd code, dispatched
+// by upstream sangfor's svpnservice. Known values:
+//
+//	0x00 = SEND_IP  (zju-connect protocol uses 0x02 here as its OK marker;
+//	                 the relationship between 0x02 and the full sangfor
+//	                 cmd table isn't fully understood, but accepting it
+//	                 has worked reliably for years)
+//	0x05/0x06/0x07/0x09 = RECONNECTLATER_*
+//	0x08 = SHUTDOWN
+//	0x0a = IPVALID
+//	0x0e/0x0f = HEARTBEAT
+//
+// Anything other than the legacy 0x02 success marker is converted into a
+// typed error so the caller can decide policy (retry / re-login / exit).
 func (c *Client) SendConn() (*tls.UConn, error) {
 	if c.token == nil {
 		return nil, errors.New("token is nil")
@@ -115,6 +150,7 @@ func (c *Client) SendConn() (*tls.UConn, error) {
 
 	n, err := conn.Write(message)
 	if err != nil {
+		_ = conn.Close()
 		return nil, err
 	}
 	log.DebugPrintf("Send handshake: wrote %d bytes", n)
@@ -123,14 +159,25 @@ func (c *Client) SendConn() (*tls.UConn, error) {
 	reply := make([]byte, 1500)
 	n, err = conn.Read(reply)
 	if err != nil {
+		_ = conn.Close()
 		return nil, err
 	}
 	log.DebugPrintf("Send handshake: read %d bytes", n)
 	log.DebugDumpHex(reply[:n])
 
-	if reply[0] != 0x02 {
-		return nil, errors.New("unexpected send handshake reply")
+	switch reply[0] {
+	case 0x02:
+		return conn, nil
+	case 0x08:
+		_ = conn.Close()
+		log.Printf("SendConn: server returned SHUTDOWN (cmd 0x08); session terminated by server")
+		return nil, ErrSangforShutdown
+	case 0x05, 0x06, 0x07, 0x09:
+		_ = conn.Close()
+		log.Printf("SendConn: server returned RECONNECTLATER (cmd 0x%02x); should re-login and retry", reply[0])
+		return nil, ErrSangforReconnectLater
+	default:
+		_ = conn.Close()
+		return nil, fmt.Errorf("unexpected send handshake reply: 0x%02x", reply[0])
 	}
-
-	return conn, err
 }

--- a/client/easyconnect/request.go
+++ b/client/easyconnect/request.go
@@ -464,6 +464,43 @@ func (c *Client) requestConfig() (string, error) {
 	return buf.String(), nil
 }
 
+// requestUpdateSession pings /por/update_session.csp to keep the server-side
+// session alive. The official EasyConnect client calls this periodically;
+// without it, sangfor servers with strict idle policies (e.g. HUST) close
+// the session, which the tunnel layer surfaces as a "broken pipe" →
+// "unexpected handshake reply" kick cascade.
+func (c *Client) requestUpdateSession() error {
+	addr := "https://" + c.server + "/por/update_session.csp?twfid=" + c.twfID + "&apiversion=1"
+
+	req, err := http.NewRequest("GET", addr, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Cookie", "TWFID="+c.twfID)
+	req.Header.Set("User-Agent", "EasyConnect_Linux_Ubuntu")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func(Body io.ReadCloser) {
+		_ = Body.Close()
+	}(resp.Body)
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	// Successful body looks like:
+	//   <Auth><Message>success</Message><ErrorCode>1</ErrorCode><TwfID>...</TwfID></Auth>
+	if !bytes.Contains(buf.Bytes(), []byte("success")) {
+		return errors.New("update_session: unexpected reply: " + buf.String())
+	}
+	return nil
+}
+
 func (c *Client) requestResources() (string, error) {
 	addr := "https://" + c.server + "/por/rclist.csp"
 	log.Printf("Request: %s", addr)

--- a/client/easyconnect/request.go
+++ b/client/easyconnect/request.go
@@ -2,11 +2,13 @@ package easyconnect
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -469,7 +471,7 @@ func (c *Client) requestConfig() (string, error) {
 // without it, sangfor servers with strict idle policies (e.g. HUST) close
 // the session, which the tunnel layer surfaces as a "broken pipe" →
 // "unexpected handshake reply" kick cascade.
-func (c *Client) requestUpdateSession() error {
+func (c *Client) requestUpdateSession(ctx context.Context) error {
 	u := url.URL{
 		Scheme: "https",
 		Host:   c.server,
@@ -480,7 +482,7 @@ func (c *Client) requestUpdateSession() error {
 	q.Set("apiversion", "1")
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -499,16 +501,22 @@ func (c *Client) requestUpdateSession() error {
 		return fmt.Errorf("update_session: unexpected status %d", resp.StatusCode)
 	}
 
-	var buf bytes.Buffer
-	_, err = io.Copy(&buf, resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
 
 	// Successful body looks like:
 	//   <Auth><Message>success</Message><ErrorCode>1</ErrorCode><TwfID>...</TwfID></Auth>
-	if !bytes.Contains(buf.Bytes(), []byte("success")) {
-		return errors.New("update_session: unexpected reply: " + buf.String())
+	var reply struct {
+		Message   string `xml:"Message"`
+		ErrorCode string `xml:"ErrorCode"`
+	}
+	if err := xml.Unmarshal(body, &reply); err != nil {
+		return fmt.Errorf("update_session: parse reply: %w", err)
+	}
+	if reply.Message != "success" || reply.ErrorCode != "1" {
+		return fmt.Errorf("update_session: unexpected reply message=%q error_code=%q", reply.Message, reply.ErrorCode)
 	}
 	return nil
 }

--- a/client/easyconnect/request.go
+++ b/client/easyconnect/request.go
@@ -470,9 +470,17 @@ func (c *Client) requestConfig() (string, error) {
 // the session, which the tunnel layer surfaces as a "broken pipe" →
 // "unexpected handshake reply" kick cascade.
 func (c *Client) requestUpdateSession() error {
-	addr := "https://" + c.server + "/por/update_session.csp?twfid=" + c.twfID + "&apiversion=1"
+	u := url.URL{
+		Scheme: "https",
+		Host:   c.server,
+		Path:   "/por/update_session.csp",
+	}
+	q := url.Values{}
+	q.Set("twfid", c.twfID)
+	q.Set("apiversion", "1")
+	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequest("GET", addr, nil)
+	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -486,6 +494,10 @@ func (c *Client) requestUpdateSession() error {
 	defer func(Body io.ReadCloser) {
 		_ = Body.Close()
 	}(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("update_session: unexpected status %d", resp.StatusCode)
+	}
 
 	var buf bytes.Buffer
 	_, err = io.Copy(&buf, resp.Body)

--- a/dial/dialer.go
+++ b/dial/dialer.go
@@ -17,6 +17,14 @@ import (
 	"errors"
 )
 
+// ErrACLDenied is returned by DialIPPort when the caller forced VPN routing
+// (via alwaysUseVPN / proxy_all) for a destination that the sangfor server
+// would not accept. Sending it through the L3 tunnel would cause the server
+// to terminate the entire session with cmd 0x08 SHUTDOWN, killing all other
+// in-flight connections. Refusing here mirrors what the official EasyConnect
+// client does and keeps the tunnel alive.
+var ErrACLDenied = errors.New("destination not in sangfor IPResources whitelist (would trigger tunnel SHUTDOWN)")
+
 type Dialer struct {
 	stack                stack.Stack
 	resolver             *resolve.Resolver
@@ -100,28 +108,45 @@ func (d *Dialer) DialIPPort(ctx context.Context, network, ipAddr string) (net.Co
 		useVPN = true
 	}
 
-	if !useVPN {
-		if res := ctx.Value(resolve.ContextKeyDomainResource); res != nil {
-			resource := res.(client.DomainResource)
-			if resource.PortMin <= port && port <= resource.PortMax {
-				if resource.Protocol == network || resource.Protocol == "all" {
-					useVPN = true
-				}
+	// Track whether dst:port matches any sangfor-issued resource. We always
+	// run both resource lookups (even if useVPN was already forced true by
+	// alwaysUseVPN) so we can enforce the server-side ACL client-side.
+	matchedResource := false
+
+	if res := ctx.Value(resolve.ContextKeyDomainResource); res != nil {
+		resource := res.(client.DomainResource)
+		if resource.PortMin <= port && port <= resource.PortMax {
+			if resource.Protocol == network || resource.Protocol == "all" {
+				useVPN = true
+				matchedResource = true
 			}
 		}
 	}
 
-	if !useVPN && d.ipResources != nil {
+	if !matchedResource && d.ipResources != nil {
 		for _, resource := range d.ipResources {
 			if bytes.Compare(target.IP, resource.IPMin) >= 0 && bytes.Compare(target.IP, resource.IPMax) <= 0 {
 				if resource.PortMin <= port && port <= resource.PortMax {
 					if resource.Protocol == network || resource.Protocol == "all" {
 						useVPN = true
+						matchedResource = true
 						break
 					}
 				}
 			}
 		}
+	}
+
+	// Client-side ACL enforcement: if alwaysUseVPN forced VPN routing for a
+	// dst:port that isn't in the server-issued resource list, sending it
+	// upstream causes sangfor to terminate the L3 tunnel (cmd 0x08 SHUTDOWN
+	// on the next handshake). The official EasyConnect client filters here
+	// via CSClient before traffic ever reaches the tunnel; we do the same.
+	// Skipped when no IPResources are parsed (parse_resource=false), since
+	// we have no whitelist to enforce.
+	if useVPN && !matchedResource && len(d.ipResources) > 0 {
+		log.Printf("ACL: refusing %s/%s — not in sangfor IPResources whitelist (would trigger tunnel SHUTDOWN)", ipAddr, network)
+		return nil, ErrACLDenied
 	}
 
 	if useVPN {

--- a/dial/dialer.go
+++ b/dial/dialer.go
@@ -142,9 +142,10 @@ func (d *Dialer) DialIPPort(ctx context.Context, network, ipAddr string) (net.Co
 	// upstream causes sangfor to terminate the L3 tunnel (cmd 0x08 SHUTDOWN
 	// on the next handshake). The official EasyConnect client filters here
 	// via CSClient before traffic ever reaches the tunnel; we do the same.
-	// Skipped when no IPResources are parsed (parse_resource=false), since
-	// we have no whitelist to enforce.
-	if useVPN && !matchedResource && len(d.ipResources) > 0 {
+	// Skipped when IPResources are unavailable (parse_resource=false), since
+	// we have no whitelist to enforce. An empty but non-nil slice still means
+	// resources were parsed and no IP destinations are allowed.
+	if useVPN && !matchedResource && d.ipResources != nil {
 		log.Printf("ACL: refusing %s/%s — not in sangfor IPResources whitelist (would trigger tunnel SHUTDOWN)", ipAddr, network)
 		return nil, ErrACLDenied
 	}

--- a/internal/hook_func/terminal_func.go
+++ b/internal/hook_func/terminal_func.go
@@ -2,6 +2,7 @@ package hook_func
 
 import (
 	"context"
+	"sync"
 
 	"github.com/mythologyli/zju-connect/log"
 )
@@ -15,8 +16,17 @@ type TerminalItem struct {
 var terminalFuncList []TerminalItem
 
 var terminalBegin = false
+var terminalMu sync.Mutex
 
 func RegisterTerminalFunc(execName string, fun TerminalFunc) {
+	terminalMu.Lock()
+	defer terminalMu.Unlock()
+
+	if terminalBegin {
+		log.Println("Terminal already started, skip registering func:", execName)
+		return
+	}
+
 	terminalFuncList = append(terminalFuncList, TerminalItem{
 		f:    fun,
 		name: execName,
@@ -25,9 +35,17 @@ func RegisterTerminalFunc(execName string, fun TerminalFunc) {
 }
 
 func ExecTerminalFunc(ctx context.Context) []error {
-	var errList []error
+	terminalMu.Lock()
+	if terminalBegin {
+		terminalMu.Unlock()
+		return nil
+	}
 	terminalBegin = true
-	for _, item := range terminalFuncList {
+	funcList := append([]TerminalItem(nil), terminalFuncList...)
+	terminalMu.Unlock()
+
+	var errList []error
+	for _, item := range funcList {
 		log.Println("Exec func on terminal:", item.name)
 		if err := item.f(ctx); err != nil {
 			errList = append(errList, err)
@@ -40,5 +58,8 @@ func ExecTerminalFunc(ctx context.Context) []error {
 }
 
 func IsTerminal() bool {
+	terminalMu.Lock()
+	defer terminalMu.Unlock()
+
 	return terminalBegin
 }

--- a/stack/gvisor/stack.go
+++ b/stack/gvisor/stack.go
@@ -3,8 +3,10 @@ package gvisor
 import (
 	"errors"
 	"io"
+	"os"
 
 	"github.com/mythologyli/zju-connect/client"
+	"github.com/mythologyli/zju-connect/client/easyconnect"
 	"github.com/mythologyli/zju-connect/internal/hook_func"
 	"github.com/mythologyli/zju-connect/internal/ippool"
 	"github.com/mythologyli/zju-connect/internal/zcdns"
@@ -97,6 +99,16 @@ func (ep *Endpoint) WritePackets(list stack.PacketBufferList) (int, tcpip.Error)
 				if errors.Is(err, client.ErrResourceNotFound) {
 					log.Printf("%v", err)
 					continue
+				}
+
+				// Server-initiated SHUTDOWN: known terminal state from
+				// sangfor (cmd 0x08). No point retrying; exit cleanly so
+				// systemd / a wrapper can do a fresh login. This is
+				// strictly better than panicking with a gvisor stack
+				// trace, which obscures the actual cause.
+				if errors.Is(err, easyconnect.ErrSangforShutdown) {
+					log.Printf("WritePackets: server SHUTDOWN; exiting for clean restart")
+					os.Exit(2)
 				}
 
 				if hook_func.IsTerminal() {

--- a/stack/gvisor/stack.go
+++ b/stack/gvisor/stack.go
@@ -1,6 +1,7 @@
 package gvisor
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -102,12 +103,16 @@ func (ep *Endpoint) WritePackets(list stack.PacketBufferList) (int, tcpip.Error)
 				}
 
 				// Server-initiated SHUTDOWN: known terminal state from
-				// sangfor (cmd 0x08). No point retrying; exit cleanly so
-				// systemd / a wrapper can do a fresh login. This is
-				// strictly better than panicking with a gvisor stack
+				// sangfor (cmd 0x08). No point retrying; run the registered
+				// cleanup hooks (DNS revert, tun device close, etc.) and
+				// exit so systemd / a wrapper can do a fresh login. This
+				// is strictly better than panicking with a gvisor stack
 				// trace, which obscures the actual cause.
 				if errors.Is(err, easyconnect.ErrSangforShutdown) {
-					log.Printf("WritePackets: server SHUTDOWN; exiting for clean restart")
+					log.Printf("WritePackets: server SHUTDOWN; running cleanup hooks and exiting for clean restart")
+					if !hook_func.IsTerminal() {
+						hook_func.ExecTerminalFunc(context.Background())
+					}
 					os.Exit(2)
 				}
 


### PR DESCRIPTION
## Summary

Three independent but related mitigations against sangfor server-side enforcement that currently surfaces in gvisor SOCKS5 mode as panics with deep gvisor stack traces. Observed extensively at HUST (vpn.hust.edu.cn). Replaces #102.

Each commit is independent and addresses a separate enforcement vector:

1. **Periodic `/por/update_session.csp` keepalive** — mitigates strict idle timeout. The official EasyConnect client does this; without it, sessions on HUST silently die after ~60s and the next L3 write panics.

2. **Typed handling of HandCmdMsg cmd codes** — `0x08` SHUTDOWN, `0x05/0x06/0x07/0x09` RECONNECTLATER. Currently every non-`0x02` reply becomes the same generic error and panics. On `0x08` we now `os.Exit(2)` for a clean restart instead of dumping a gvisor stack trace. Cmd-code semantics identified via reverse engineering of `svpnservice` (jumptable @ 0x4e6fd0 in EasyConnect 7.6.7).

3. **Client-side ACL filter at the dialer** (closes #79) — mirrors what CSClient does in the official client. When `proxy_all` forces VPN routing for a dst:port not covered by any IPResource/DomainResource, refuse locally instead of forwarding upstream. Otherwise sangfor terminates the entire L3 tunnel on the first non-whitelisted packet, killing every in-flight connection. Skipped when no IPResources are parsed, so it's a no-op for users who run with `parse_resource=false`.

## Why this matters

Together these explain a long-standing class of "browser-triggered crash" reports (see #79): the user opens an internal page that loads a sub-resource on a non-whitelisted port (admin/metrics endpoint, secondary service on :8000, etc.), the server SHUTDOWNs the tunnel, the L3Conn retry path opens a fresh SendConn, gets `0x08` again, and the panic surfaces with a gvisor trace that doesn't mention sangfor at all.

After this PR, the same access pattern produces a clean per-connection refusal, the tunnel stays alive, and other tabs / apps keep working.

## Test plan

Tested against vpn.hust.edu.cn (sangfor M7.6.8):

- [x] `proxy_all=true` + curl to whitelisted `222.20.126.160:80` → HTTP 200 (unchanged behaviour)
- [x] `proxy_all=true` + curl to non-whitelisted `222.20.126.160:8000` → connection refused with `ACL: refusing 222.20.126.160:8000/tcp — not in sangfor IPResources whitelist` log line
- [x] After the refusal, the next `222.20.126.160:80` curl still returns HTTP 200 (tunnel survived)
- [x] When the server *does* send cmd `0x08` (e.g. due to an unrelated session conflict), process exits cleanly with code 2 and a single log line, no gvisor stack trace
- [x] Keepalive ticker fires `/por/update_session.csp` every 60s, server replies with `Message=success` (verified via mitmproxy capture against the official client and against this build)