### PR TITLE
fix: handle atrust l3 auth timeout

### DIFF
--- a/client/atrust/l3tunnelconn.go
+++ b/client/atrust/l3tunnelconn.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -32,6 +33,8 @@ const (
 	cmdSecondVipReq  = 0x16
 	cmdSecondVipResp = 0x96
 )
+
+var errL3TunnelAuthTimeout = errors.New("l3-tunnel auth timeout")
 
 type clientInfo struct {
 	sid          string
@@ -365,7 +368,7 @@ func (c *l3TunnelConn) ensureAuth(ct *conntrack, meta packetMeta) error {
 	case <-ct.authCh:
 		return ct.authErr
 	case <-time.After(8 * time.Second):
-		return fmt.Errorf("l3-tunnel auth timeout for %s", ct.key)
+		return fmt.Errorf("%w for %s", errL3TunnelAuthTimeout, ct.key)
 	}
 }
 

--- a/client/atrust/l3tunnelpacket.go
+++ b/client/atrust/l3tunnelpacket.go
@@ -64,7 +64,7 @@ func (t *L3Tunnel) writePacket(packet zctcpip.IPv4Packet, appID, nodeGroupID str
 	err = conn.WritePacket(meta, appID, nodeGroupID, packet)
 	for retry := 0; retry < 5 && isClosedConnErr(err); retry++ {
 		// If the cached tunnel conn was closed by network flaps, evict it and retry.
-		log.Println("Write packet failed with closed connection, evicting conn and retrying...")
+		log.Printf("Write packet failed with closed connection, evicting conn and retrying: %v", err)
 		t.evictConn(nodeGroupID, conn)
 		retryConn, retryErr := t.getConn(nodeGroupID)
 		if retryErr != nil {
@@ -72,6 +72,23 @@ func (t *L3Tunnel) writePacket(packet zctcpip.IPv4Packet, appID, nodeGroupID str
 		}
 		conn = retryConn
 		err = conn.WritePacket(meta, appID, nodeGroupID, packet)
+	}
+	if isAuthTimeoutErr(err) {
+		// Auth timeout can leave the conntrack entry stuck without a token.
+		// Rebuild the tunnel once; if it still fails, let the stack drop this packet.
+		log.Printf("Write packet failed with auth timeout, evicting conn and retrying once: %v", err)
+		t.evictConn(nodeGroupID, conn)
+		retryConn, retryErr := t.getConn(nodeGroupID)
+		if retryErr != nil {
+			return retryErr
+		}
+		conn = retryConn
+		err = conn.WritePacket(meta, appID, nodeGroupID, packet)
+	}
+	if isAuthTimeoutErr(err) {
+		log.Printf("Drop packet after l3-tunnel auth timeout retry failed: %v", err)
+		t.evictConn(nodeGroupID, conn)
+		return nil
 	}
 	return err
 }
@@ -84,6 +101,10 @@ func isClosedConnErr(err error) bool {
 		return true
 	}
 	return strings.Contains(err.Error(), "use of closed network connection")
+}
+
+func isAuthTimeoutErr(err error) bool {
+	return errors.Is(err, errL3TunnelAuthTimeout)
 }
 
 func buildPacketMeta(packet zctcpip.IPv4Packet) (packetMeta, error) {

--- a/client/atrust/l3tunnelpacket_test.go
+++ b/client/atrust/l3tunnelpacket_test.go
@@ -1,0 +1,21 @@
+package atrust
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsAuthTimeoutErr(t *testing.T) {
+	err := fmt.Errorf("%w for 4:<client-ip>:<client-port>-<dns-server>:53", errL3TunnelAuthTimeout)
+	if !isAuthTimeoutErr(err) {
+		t.Fatal("expected wrapped l3 tunnel auth timeout to be recognized")
+	}
+
+	if isAuthTimeoutErr(nil) {
+		t.Fatal("nil error must not be treated as auth timeout")
+	}
+
+	if isAuthTimeoutErr(fmt.Errorf("l3-tunnel auth timeout for unrelated text")) {
+		t.Fatal("plain text error must not be treated as auth timeout")
+	}
+}


### PR DESCRIPTION
## Summary

This fixes an aTrust L3 tunnel crash when packet auth times out.

In the observed case, a UDP DNS packet hit the L3 auth timeout path. The error was returned from `L3Conn.Write`, then `stack/gvisor.(*Endpoint).WritePackets` treated it as a fatal write error and panicked in background mode. When zju-connect was run by launchd with `KeepAlive`, launchd restarted it, but the SOCKS listener disappeared during the restart window and existing SSH/tunnel sessions were closed.

This patch:

- wraps L3 auth timeout with a sentinel error so callers can identify it with `errors.Is`
- evicts the cached L3 tunnel connection and retries once when auth times out
- if the retry also times out, evicts that connection and drops the current packet instead of returning the timeout to the gVisor write path
- keeps the existing closed-connection retry behavior
- adds a small unit test for auth-timeout error detection

## Sanitized Log

The sensitive fields below are redacted. The original values included a private client VIP, an ephemeral port, and the internal DNS server.

```text
2026/06/04 00:12:02 KeepAlive using UDP: OK
panic: l3-tunnel auth timeout for 4:<client-vip>:<client-port>-<zju-dns>:53

goroutine <id> [running]:
github.com/mythologyli/zju-connect/stack/gvisor.(*Endpoint).WritePackets(...)
    github.com/mythologyli/zju-connect/stack/gvisor/stack.go:105 +0x258
gvisor.dev/gvisor/pkg/tcpip/stack.(*delegatingQueueingDiscipline).WritePacket(...)
gvisor.dev/gvisor/pkg/tcpip/transport/udp.(*endpoint).Write(...)
gvisor.dev/gvisor/pkg/tcpip/adapters/gonet.(*UDPConn).Write(...)
net.dnsPacketRoundTrip(...)
net.(*Resolver).exchange(...)
```

After the panic, launchd restarted zju-connect and dependent SOCKS clients saw closed connections:

```text
[SOCKS5] server: readfrom tcp 127.0.0.1:1090->127.0.0.1:<client-port>: connection closed by server
Connection to <campus-host> closed by remote host.
```

## Reproduction

Environment where this was observed:

- macOS arm64
- zju-connect v1.1.1
- `protocol = "atrust"`
- `tcp_tunnel_mode = false`
- SOCKS listener on `127.0.0.1:1090`
- Clash/Mihomo TUN mode routing campus CIDRs, for example `10.0.0.0/8`, to the zju-connect SOCKS proxy
- zju-connect managed by launchd with `KeepAlive`

Steps:

1. Start zju-connect with aTrust L3 tunnel enabled.
2. Route campus traffic through its SOCKS proxy.
3. Open a long-running SSH session or tunnel to a campus host, for example `ssh <campus-host>` where the target is in `10.0.0.0/8`.
4. Keep normal DNS and TCP traffic flowing through the proxy.
5. When an L3 auth response for a UDP DNS packet is delayed long enough to hit `ensureAuth`'s 8 second timeout, zju-connect panics at the gVisor write path.

Expected behavior: a single L3 auth timeout should not kill the whole process.

Actual behavior before this patch: zju-connect panicked, launchd restarted it, SOCKS `1090` was briefly unavailable, and existing SSH/tunnel sessions were dropped.

## Verification

Run from an isolated worktree. No local service binary was installed or restarted during PR preparation.

```text
GOTOOLCHAIN=local go test -vet=off ./client/atrust
ok   github.com/mythologyli/zju-connect/client/atrust

GOTOOLCHAIN=local go test -vet=off ./...
ok   github.com/mythologyli/zju-connect/client/atrust
ok   github.com/mythologyli/zju-connect/client/atrust/auth
...

GOTOOLCHAIN=local go build -v -o /tmp/zju-connect-pr-build/zju-connect -trimpath -ldflags "-s -w -buildid= -X 'main.CommitID=pr-auth-timeout'" .
/tmp/zju-connect-pr-build/zju-connect: Mach-O 64-bit executable arm64
```

Note: plain `go test ./...` currently trips existing Go vet warnings about non-constant log format strings in unrelated packages, so the validation above disables vet.
