### PR TITLE
fix(easyconnect): accept cert login success with Result=0

### DIFF
--- a/client/easyconnect/request.go
+++ b/client/easyconnect/request.go
@@ -430,12 +430,26 @@ func (c *Client) loginCert() error {
 		_ = Body.Close()
 	}(resp.Body)
 
-	if !strings.Contains(buf.String(), "<Result>1</Result>") {
+	response := buf.String()
+	certSuccess := strings.Contains(response, "<Result>1</Result>") ||
+		strings.Contains(response, "Login successfully") ||
+		strings.Contains(response, "Auth cert suc")
+	if !certSuccess {
 		debug.PrintStack()
-		return errors.New("Cert verification failed: " + buf.String())
+		return errors.New("Cert verification failed: " + response)
 	}
 
-	log.Print("Cert verification success")
+	twfIDMatch := regexp.MustCompile(`<TwfID>(.*)</TwfID>`).FindSubmatch(buf.Bytes())
+	if twfIDMatch != nil {
+		c.twfID = string(twfIDMatch[1])
+		log.Printf("Update TWFID: %s", c.twfID)
+	}
+
+	if strings.Contains(response, "<pwpErrorCode>16</pwpErrorCode>") {
+		log.Print("Cert verification success (server returned pwpErrorCode=16, profile redirect ignored)")
+	} else {
+		log.Print("Cert verification success")
+	}
 
 	return nil
 }


### PR DESCRIPTION
Some Sangfor M7.6.8R2 servers return Login successfully with <Result>0</Result> and pwpErrorCode=16 (profile redirect) after certificate auth. Treat that as success, update TwfID from the response, and ignore the profile redirect.


## Original output
```
2026/06/27 18:09:43 Register func on terminal: CloseHTTPListener
Jun 26 21:56:27 :         github.com/mythologyli/zju-connect/client/client.go:123 +0x27
Jun 26 21:56:27 : main.main()
Jun 26 21:56:27 :         github.com/mythologyli/zju-connect/main.go:77 +0x6c7
Jun 26 21:56:27 : 2026/06/26 21:56:27 EasyConnect client setup error: Cert verification failed: <?xml version="1.0" encoding="utf-8"?>
Jun 26 21:56:27 : <Auth>
Jun 26 21:56:27 :         <CSRF_RAND_CODE>1234567890</CSRF_RAND_CODE>
Jun 26 21:56:27 :         <EnableMAM>0</EnableMAM>
Jun 26 21:56:27 :         <CERT_USERNAME>user</CERT_USERNAME>
Jun 26 21:56:27 :         <LBEnabled>0</LBEnabled>
Jun 26 21:56:27 :         <Note><![CDATA[Location=https://url:port/por/perinfo.csp?pwp_errorcode=16]]></Note>
Jun 26 21:56:27 :         <Message><![CDATA[Login successfully!]]></Message>
Jun 26 21:56:27 :         <Result>0</Result>
Jun 26 21:56:27 :         <TwfID>1a2b3c4d5e6f7g8h9i0j</TwfID>
Jun 26 21:56:27 :         <pwpErrorCode>16</pwpErrorCode>
Jun 26 21:56:27 :         <ErrorCode>1</ErrorCode>
Jun 26 21:56:27 :         <CurAuth>0</CurAuth>
Jun 26 21:56:27 :         <AuthInfo><![CDATA[]]></AuthInfo>
Jun 26 21:56:27 :         <IsFirstAuth>0</IsFirstAuth>
Jun 26 21:56:27 : </Auth>
```

## Summary
- Handle Sangfor M7.6.8R2 cert login responses that return `<Result>0</Result>` with `Login successfully!` and `pwpErrorCode=16`
- Update TwfID from cert auth response before continuing setup
