### PR TITLE
fix: use browser TLS fingerprint for aTrust TCP tunnels

### DIFF
--- a/client/atrust/tcptunnel.go
+++ b/client/atrust/tcptunnel.go
@@ -7,7 +7,6 @@ import (
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
-	"crypto/tls"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -22,7 +21,7 @@ import (
 )
 
 type tcpTunnelConn struct {
-	tlsConn *tls.Conn
+	tlsConn net.Conn
 	reader  *bufio.Reader
 	readBuf []byte
 }
@@ -199,9 +198,7 @@ func (c *Client) DialTCP(ctx context.Context, addr *net.TCPAddr) (net.Conn, erro
 	if nodeAddr == "" {
 		return nil, fmt.Errorf("no available aTrust node for group %q", nodeGroupID)
 	}
-	conn, err := tls.Dial("tcp", nodeAddr, &tls.Config{
-		InsecureSkipVerify: true,
-	})
+	conn, err := dialATrustTLS(nodeAddr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to aTrust server: %w", err)
 	}

--- a/client/atrust/tcptunnel_tls.go
+++ b/client/atrust/tcptunnel_tls.go
@@ -1,0 +1,53 @@
+package atrust
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+
+	utls "github.com/refraction-networking/utls"
+)
+
+func newATrustTLSClient(conn net.Conn, serverName string) *utls.UConn {
+	return utls.UClient(conn, &utls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         serverName,
+	}, utls.HelloChrome_Auto)
+}
+
+func aTrustTLSServerName(addr string) (string, error) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", fmt.Errorf("parse aTrust node address: %w", err)
+	}
+	if net.ParseIP(host) != nil {
+		return "", nil
+	}
+	return host, nil
+}
+
+// Prefer a browser ClientHello for affected gateways while retaining the original TLS client as a fallback.
+func dialATrustTLS(addr string) (net.Conn, error) {
+	serverName, err := aTrustTLSServerName(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	rawConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	conn := newATrustTLSClient(rawConn, serverName)
+	chromeErr := conn.Handshake()
+	if chromeErr == nil {
+		return conn, nil
+	}
+	_ = rawConn.Close()
+
+	fallback, fallbackErr := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true})
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("aTrust TLS handshake failed with Chrome fingerprint: %v; crypto/tls fallback failed: %w", chromeErr, fallbackErr)
+	}
+	return fallback, nil
+}

--- a/client/atrust/tcptunnel_tls_test.go
+++ b/client/atrust/tcptunnel_tls_test.go
@@ -1,0 +1,121 @@
+package atrust
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	utls "github.com/refraction-networking/utls"
+)
+
+func TestNewATrustTLSClientUsesChromeFingerprint(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	client := newATrustTLSClient(clientConn, "vpn.example.com")
+	if client.ClientHelloID.Client != utls.HelloChrome_Auto.Client ||
+		client.ClientHelloID.Version != utls.HelloChrome_Auto.Version {
+		t.Fatalf("aTrust ClientHello = %s/%s, want %s/%s",
+			client.ClientHelloID.Client,
+			client.ClientHelloID.Version,
+			utls.HelloChrome_Auto.Client,
+			utls.HelloChrome_Auto.Version,
+		)
+	}
+}
+
+func TestATrustTLSServerName(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{name: "hostname", addr: "vpn.example.com:441", want: "vpn.example.com"},
+		{name: "ipv4", addr: "192.0.2.1:441", want: ""},
+		{name: "ipv6", addr: "[2001:db8::1]:441", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := aTrustTLSServerName(tt.addr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("server name for %q = %q, want %q", tt.addr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDialATrustTLSUsesChromeFingerprint(t *testing.T) {
+	addr, serverDone := startHandshakeServer(t, false)
+
+	conn, err := dialATrustTLS(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, ok := conn.(*utls.UConn); !ok {
+		t.Fatalf("connection type = %T, want *tls.UConn", conn)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDialATrustTLSFallsBackToCryptoTLS(t *testing.T) {
+	addr, serverDone := startHandshakeServer(t, true)
+
+	conn, err := dialATrustTLS(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, ok := conn.(*tls.Conn); !ok {
+		t.Fatalf("fallback connection type = %T, want *tls.Conn", conn)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func startHandshakeServer(t *testing.T, rejectFirst bool) (string, <-chan error) {
+	t.Helper()
+
+	template := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	serverConfig := &tls.Config{Certificates: template.TLS.Certificates}
+	template.Close()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan error, 1)
+	go func() {
+		defer listener.Close()
+		if rejectFirst {
+			conn, err := listener.Accept()
+			if err != nil {
+				done <- err
+				return
+			}
+			_ = conn.Close()
+		}
+
+		conn, err := listener.Accept()
+		if err != nil {
+			done <- err
+			return
+		}
+		defer conn.Close()
+		done <- tls.Server(conn, serverConfig).Handshake()
+	}()
+
+	return listener.Addr().String(), done
+}


### PR DESCRIPTION
## Problem

On some aTrust gateways, the first full-sized TCP segment sent after Go's default `crypto/tls` ClientHello is not acknowledged until retransmission. Each TCP tunnel can therefore wait for one or more retransmission timeouts even when the network RTT is low.

## Fix

- Prefer the existing uTLS dependency with `HelloChrome_Auto` for aTrust TCP tunnel handshakes.
- Preserve SNI for hostname node addresses and omit it for IP literals.
- Fall back to the original `crypto/tls` dialer if the browser-style handshake is rejected.
- Leave authentication, protocol framing, L3 transport, and configuration unchanged.

## Compatibility

The change adds no dependency or configuration option. Gateways that accept the browser-style ClientHello use the low-latency path; gateways that do not accept it retain the previous TLS behavior through the tested fallback.

## Validation

- `go test ./client/atrust -count=20`
- `go test -race ./client/atrust -count=1`
- `go vet ./client/atrust`
- `go test -vet=off ./...`
- `go build ./...`
- Cross-compiled all 16 GOOS/GOARCH targets from the repository's build matrix.
- Verified against an affected gateway: five TCP tunnel handshakes completed in 0.10-0.12 s, with interactive round-trip latency at 13.4 ms median / 15.2 ms p95.
