### PR TITLE
fix(easyconnect): skip route prefixes containing VPN server IP to prevent TUN dead loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -236,9 +236,25 @@ func main() {
 		}
 
 		if conf.AddRoute && ipSet != nil {
+			// Resolve VPN server IPs to detect routing conflicts.
+			// If a route prefix contains the VPN server IP, skip it to
+			// prevent a dead loop where the TLS control connection is
+			// routed into the TUN device it is supposed to carry.
+			serverIPs, _ := net.LookupHost(conf.ServerAddress)
 			for _, prefix := range ipSet.Prefixes() {
-				log.Printf("Add route to %s", prefix.String())
-				_ = vpnTUNStack.AddRoute(prefix.String())
+				skip := false
+				for _, serverIPStr := range serverIPs {
+					serverIP, err := netaddr.ParseIP(serverIPStr)
+					if err == nil && prefix.Contains(serverIP) {
+						log.Printf("WARNING: Skip route %s (contains VPN server %s)", prefix.String(), serverIPStr)
+						skip = true
+						break
+					}
+				}
+				if !skip {
+					log.Printf("Add route to %s", prefix.String())
+					_ = vpnTUNStack.AddRoute(prefix.String())
+				}
 			}
 		} else if !conf.AddRoute && !conf.DisableZJUConfig && conf.Protocol == "easyconnect" {
 			log.Println("Add route to 10.0.0.0/8")


### PR DESCRIPTION
## 问题

EasyConnect + TUN 模式 + `-add-route` 时，若 VPN 服务器 IP 落在资源路由前缀内，会造成路由死循环，约 30 秒后 panic。

例如 西北工业大学 (`vpn.nwpu.edu.cn`)：服务器 IP `202.117.80.11` 恰好被资源路由 `202.117.80.0/20` 覆盖，添加该路由后 TLS 控制连接被绑架到 TUN 设备，而 TUN 又依赖此连接，形成死循环。

## 修复

添加路由前解析 VPN 服务器 IP，跳过包含该 IP 的前缀并打印 WARNING。被跳过的前缀范围内的资源仍可通过 SOCKS5/HTTP 代理访问。

## 影响范围

仅当资源路由前缀包含 VPN 服务器 IP 时触发，aTrust 等正常场景不受影响。
