### PR TITLE
fix: wait for aTrust TCP tunnel connect status

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@
 
 + `tcp-tunnel-mode`: TCP 隧道模式，默认为 `false`。启用后仅可通过 TCP 隧道代理 TCP 流量。由于只有 aTrust 支持 TCP 隧道，此模式在 EasyConnect 下无效。启用后会禁用 TUN 模式
 
++ `skip-tcp-tunnel-wait`: 不等待 aTrust TCP 隧道连接状态，默认为 `false`。仅用于兼容不返回连接状态的服务端；启用后连接失败可能要到后续读写时才能发现
+
 + `tun-mode`: TUN 模式（实验性）。请阅读 TUN 模式注意事项
 
 + `add-route`: 启用 TUN 模式时根据服务端下发配置添加路由

--- a/README_en.md
+++ b/README_en.md
@@ -129,6 +129,8 @@
 
 + `tcp-tunnel-mode`: TCP tunnel mode, default is `false`. When enabled, only TCP traffic can be proxied through the TCP tunnel. Since only aTrust supports TCP tunneling, this mode is ineffective under EasyConnect. Enabling this will disable TUN mode
 
++ `skip-tcp-tunnel-wait`: Do not wait for the aTrust TCP tunnel connection status, default is `false`. This is intended only for compatibility with servers that do not return connection status; connection failures may then be detected only during subsequent I/O
+
 + `tun-mode`: TUN mode (experimental). Please read the TUN mode precautions below
 
 + `add-route`: Add routes according to the configuration issued by the server when TUN mode is enabled

--- a/client/atrust/client.go
+++ b/client/atrust/client.go
@@ -49,6 +49,12 @@ type Client struct {
 	lifecycleCancel context.CancelFunc
 	closeOnce       sync.Once
 	underlayDialer  *underlay.Dialer
+
+	skipTCPTunnelWait bool
+}
+
+func (c *Client) SetSkipTCPTunnelWait(skip bool) {
+	c.skipTCPTunnelWait = skip
 }
 
 func NewClient(username, sid, deviceID, signKey string) *Client {

--- a/client/atrust/tcptunnel.go
+++ b/client/atrust/tcptunnel.go
@@ -27,6 +27,86 @@ type tcpTunnelConn struct {
 	readBuf []byte
 }
 
+func readTCPProtocolResponse(reader *bufio.Reader) (string, error) {
+	lengthBytes := make([]byte, 2)
+	if _, err := io.ReadFull(reader, lengthBytes); err != nil {
+		return "", err
+	}
+	data := make([]byte, binary.BigEndian.Uint16(lengthBytes))
+	if _, err := io.ReadFull(reader, data); err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func waitForTCPConnect(conn net.Conn, reader *bufio.Reader) error {
+	for {
+		header := make([]byte, 2)
+		if _, err := io.ReadFull(reader, header); err != nil {
+			return fmt.Errorf("failed to read tcp tunnel response: %w", err)
+		}
+		log.DebugPrint("Received header: ", fmt.Sprintf("%02X %02X", header[0], header[1]))
+		if header[0] == 0x05 && header[1] == 0x81 {
+			continue
+		}
+		if header[0] != 0x53 || header[1] != 0x00 {
+			return fmt.Errorf("unexpected tcp tunnel response: %02X %02X", header[0], header[1])
+		}
+
+		response, err := readTCPProtocolResponse(reader)
+		if err != nil {
+			return fmt.Errorf("failed to read tcp tunnel protocol response: %w", err)
+		}
+		log.DebugPrint("Received protocol response:")
+		log.DebugDumpHex([]byte(response))
+		if !strings.Contains(response, "OK") {
+			return fmt.Errorf("tcp tunnel setup failed: %s", response)
+		}
+		break
+	}
+
+	probe := []byte{0x01, 0x00, 0x00, 0x00}
+	if n, err := conn.Write(probe); err != nil {
+		return fmt.Errorf("failed to send tcp tunnel connect probe: %w", err)
+	} else if n != len(probe) {
+		return fmt.Errorf("failed to send tcp tunnel connect probe: %w", io.ErrShortWrite)
+	}
+	log.DebugPrint("Sent TCP connect probe")
+	log.DebugDumpHex(probe)
+
+	status := make([]byte, 2)
+	if _, err := io.ReadFull(reader, status); err != nil {
+		return fmt.Errorf("failed to read tcp tunnel connect status: %w", err)
+	}
+	log.DebugPrint("Received TCP connect status: ", fmt.Sprintf("%02X %02X", status[0], status[1]))
+	if status[0] != 0x05 {
+		return fmt.Errorf("unexpected tcp tunnel connect status: %02X %02X", status[0], status[1])
+	}
+
+	switch status[1] {
+	case 0x00:
+		return nil
+	case 0x01:
+		return fmt.Errorf("tcp tunnel server failure")
+	case 0x02:
+		return fmt.Errorf("tcp tunnel connection not allowed")
+	case 0x03:
+		return fmt.Errorf("network is unreachable")
+	case 0x04:
+		return fmt.Errorf("host is unreachable")
+	case 0x05:
+		return fmt.Errorf("connection refused")
+	case 0x06:
+		return fmt.Errorf("tcp tunnel TTL expired")
+	case 0x07:
+		return fmt.Errorf("tcp tunnel command not supported")
+	case 0x08:
+		return fmt.Errorf("tcp tunnel address type not supported")
+	default:
+		return fmt.Errorf("tcp tunnel connect failed with status 0x%02X", status[1])
+	}
+}
+
 func (c *tcpTunnelConn) Read(b []byte) (int, error) {
 	if len(c.readBuf) > 0 {
 		n := copy(b, c.readBuf)
@@ -273,8 +353,13 @@ func (c *Client) DialTCP(ctx context.Context, addr *net.TCPAddr) (net.Conn, erro
 	}
 	log.DebugDumpHex(destMsg)
 
-	return &tcpTunnelConn{
+	tunnelConn := &tcpTunnelConn{
 		tlsConn: conn,
 		reader:  bufio.NewReader(conn),
-	}, nil
+	}
+	if err := waitForTCPConnect(conn, tunnelConn.reader); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return tunnelConn, nil
 }

--- a/client/atrust/tcptunnel.go
+++ b/client/atrust/tcptunnel.go
@@ -39,7 +39,25 @@ func readTCPProtocolResponse(reader *bufio.Reader) (string, error) {
 	return string(data), nil
 }
 
-func waitForTCPConnect(conn net.Conn, reader *bufio.Reader) error {
+func waitForTCPConnect(ctx context.Context, conn net.Conn, reader *bufio.Reader) (err error) {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	cancelDone := make(chan struct{})
+	stopCancel := context.AfterFunc(ctx, func() {
+		defer close(cancelDone)
+		_ = conn.Close()
+	})
+	defer func() {
+		if !stopCancel() {
+			<-cancelDone
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
+		}
+	}()
+
 	for {
 		header := make([]byte, 2)
 		if _, err := io.ReadFull(reader, header); err != nil {
@@ -357,7 +375,7 @@ func (c *Client) DialTCP(ctx context.Context, addr *net.TCPAddr) (net.Conn, erro
 		tlsConn: conn,
 		reader:  bufio.NewReader(conn),
 	}
-	if err := waitForTCPConnect(conn, tunnelConn.reader); err != nil {
+	if err := waitForTCPConnect(ctx, conn, tunnelConn.reader); err != nil {
 		_ = conn.Close()
 		return nil, err
 	}

--- a/client/atrust/tcptunnel.go
+++ b/client/atrust/tcptunnel.go
@@ -125,6 +125,13 @@ func waitForTCPConnect(ctx context.Context, conn net.Conn, reader *bufio.Reader)
 	}
 }
 
+func (c *Client) waitForTCPConnect(ctx context.Context, conn net.Conn, reader *bufio.Reader) error {
+	if c.skipTCPTunnelWait {
+		return nil
+	}
+	return waitForTCPConnect(ctx, conn, reader)
+}
+
 func (c *tcpTunnelConn) Read(b []byte) (int, error) {
 	if len(c.readBuf) > 0 {
 		n := copy(b, c.readBuf)
@@ -375,7 +382,7 @@ func (c *Client) DialTCP(ctx context.Context, addr *net.TCPAddr) (net.Conn, erro
 		tlsConn: conn,
 		reader:  bufio.NewReader(conn),
 	}
-	if err := waitForTCPConnect(ctx, conn, tunnelConn.reader); err != nil {
+	if err := c.waitForTCPConnect(ctx, conn, tunnelConn.reader); err != nil {
 		_ = conn.Close()
 		return nil, err
 	}

--- a/client/atrust/tcptunnel_test.go
+++ b/client/atrust/tcptunnel_test.go
@@ -1,0 +1,133 @@
+package atrust
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func runTCPConnectExchange(t *testing.T, status byte) (error, []byte) {
+	t.Helper()
+
+	client, server := net.Pipe()
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+
+	probeCh := make(chan []byte, 1)
+	serverErrCh := make(chan error, 1)
+	go func() {
+		setupResponse := []byte{0x05, 0x81, 0x53, 0x00, 0x00, 0x02, 'O', 'K'}
+		for _, value := range setupResponse {
+			if _, err := server.Write([]byte{value}); err != nil {
+				serverErrCh <- err
+				return
+			}
+		}
+
+		probe := make([]byte, 4)
+		if _, err := io.ReadFull(server, probe); err != nil {
+			serverErrCh <- err
+			return
+		}
+		probeCh <- probe
+		_, err := server.Write([]byte{0x05, status})
+		serverErrCh <- err
+	}()
+
+	err := waitForTCPConnect(context.Background(), client, bufio.NewReader(client))
+	probe := <-probeCh
+	if serverErr := <-serverErrCh; serverErr != nil {
+		t.Fatalf("server exchange failed: %v", serverErr)
+	}
+	return err, probe
+}
+
+func TestWaitForTCPConnectStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     byte
+		wantErrMsg string
+	}{
+		{name: "connected", status: 0x00},
+		{name: "server failure", status: 0x01, wantErrMsg: "tcp tunnel server failure"},
+		{name: "not allowed", status: 0x02, wantErrMsg: "tcp tunnel connection not allowed"},
+		{name: "network unreachable", status: 0x03, wantErrMsg: "network is unreachable"},
+		{name: "host unreachable", status: 0x04, wantErrMsg: "host is unreachable"},
+		{name: "refused", status: 0x05, wantErrMsg: "connection refused"},
+		{name: "TTL expired", status: 0x06, wantErrMsg: "tcp tunnel TTL expired"},
+		{name: "command unsupported", status: 0x07, wantErrMsg: "tcp tunnel command not supported"},
+		{name: "address type unsupported", status: 0x08, wantErrMsg: "tcp tunnel address type not supported"},
+		{name: "unknown", status: 0xff, wantErrMsg: "tcp tunnel connect failed with status 0xFF"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err, probe := runTCPConnectExchange(t, test.status)
+			if string(probe) != string([]byte{0x01, 0x00, 0x00, 0x00}) {
+				t.Fatalf("unexpected connect probe: % X", probe)
+			}
+			if test.wantErrMsg == "" {
+				if err != nil {
+					t.Fatalf("waitForTCPConnect() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErrMsg) {
+				t.Fatalf("waitForTCPConnect() error = %v, want message %q", err, test.wantErrMsg)
+			}
+		})
+	}
+}
+
+type signalingReader struct {
+	io.Reader
+	once    sync.Once
+	started chan struct{}
+}
+
+func (r *signalingReader) Read(p []byte) (int, error) {
+	r.once.Do(func() { close(r.started) })
+	return r.Reader.Read(p)
+}
+
+func TestWaitForTCPConnectHonorsContextCancellation(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	started := make(chan struct{})
+	reader := bufio.NewReader(&signalingReader{Reader: client, started: started})
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- waitForTCPConnect(ctx, client, reader)
+	}()
+
+	<-started
+	cancel()
+	if err := <-resultCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForTCPConnect() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestWaitForTCPConnectRejectsMalformedResponse(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	go func() {
+		_, _ = server.Write([]byte{0x01, 0x00})
+	}()
+
+	err := waitForTCPConnect(context.Background(), client, bufio.NewReader(client))
+	if err == nil || !strings.Contains(err.Error(), "unexpected tcp tunnel response: 01 00") {
+		t.Fatalf("waitForTCPConnect() error = %v", err)
+	}
+}

--- a/client/atrust/tcptunnel_test.go
+++ b/client/atrust/tcptunnel_test.go
@@ -131,3 +131,15 @@ func TestWaitForTCPConnectRejectsMalformedResponse(t *testing.T) {
 		t.Fatalf("waitForTCPConnect() error = %v", err)
 	}
 }
+
+func TestClientWaitForTCPConnectCanBeSkipped(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	client := &Client{skipTCPTunnelWait: true}
+	err := client.waitForTCPConnect(context.Background(), clientConn, bufio.NewReader(clientConn))
+	if err != nil {
+		t.Fatalf("waitForTCPConnect() error = %v", err)
+	}
+}

--- a/configs/config.go
+++ b/configs/config.go
@@ -57,6 +57,7 @@ type (
 		SignKey                 string
 		ResourceFile            string
 		UpdateBestNodesInterval int
+		SkipTCPTunnelWait       bool
 	}
 
 	SinglePortForwarding struct {
@@ -120,6 +121,7 @@ type (
 		SignKey                 *string                    `toml:"sign_key"`
 		ResourceFile            *string                    `toml:"resource_file"`
 		UpdateBestNodesInterval *int                       `toml:"update_best_nodes_interval"`
+		SkipTCPTunnelWait       *bool                      `toml:"skip_tcp_tunnel_wait"`
 		BindInterface           *string                    `toml:"bind_interface"`
 		AutoDetectInterface     *bool                      `toml:"auto_detect_interface"`
 	}

--- a/init.go
+++ b/init.go
@@ -82,6 +82,7 @@ func parseTOMLConfig(configFile string, conf *configs.Config) error {
 	conf.SignKey = getTOMLVal(confTOML.SignKey, "")
 	conf.ResourceFile = getTOMLVal(confTOML.ResourceFile, "")
 	conf.UpdateBestNodesInterval = getTOMLVal(confTOML.UpdateBestNodesInterval, 300)
+	conf.SkipTCPTunnelWait = getTOMLVal(confTOML.SkipTCPTunnelWait, false)
 
 	for _, singlePortForwarding := range confTOML.PortForwarding {
 		if singlePortForwarding.NetworkType == nil {
@@ -185,6 +186,7 @@ func init() {
 	flag.StringVar(&conf.SignKey, "sign-key", "", "aTrust Sign Key (mostly for debug usage)")
 	flag.StringVar(&conf.ResourceFile, "resource-file", "", "aTrust Resource File (mostly for debug usage)")
 	flag.IntVar(&conf.UpdateBestNodesInterval, "update-best-nodes-interval", 300, "Interval to update best nodes in seconds. Set to 0 to disable")
+	flag.BoolVar(&conf.SkipTCPTunnelWait, "skip-tcp-tunnel-wait", false, "Don't wait for aTrust TCP tunnel connection status")
 	flag.StringVar(&tcpPortForwarding, "tcp-port-forwarding", "", "TCP port forwarding (e.g. 0.0.0.0:9898-10.10.98.98:80,127.0.0.1:9899-10.10.98.98:80)")
 	flag.StringVar(&udpPortForwarding, "udp-port-forwarding", "", "UDP port forwarding (e.g. 127.0.0.1:53-10.10.0.21:53)")
 	flag.StringVar(&customDns, "custom-dns", "", "Custom set dns lookup (e.g. www.cc98.org:10.10.98.98,appservice.zju.edu.cn:10.203.8.198)")

--- a/main.go
+++ b/main.go
@@ -112,6 +112,7 @@ func main() {
 		}
 
 		vpnClient = atrustclient.NewClient(conf.Username, conf.SID, conf.DeviceID, conf.SignKey)
+		vpnClient.(*atrustclient.Client).SetSkipTCPTunnelWait(conf.SkipTCPTunnelWait)
 
 		log.Printf("VPN protocol: %s", conf.Protocol)
 		clientData, err = vpnClient.(*atrustclient.Client).Setup(


### PR DESCRIPTION
# fix: wait for aTrust TCP tunnel connect status

## Summary

This fixes aTrust TCP Tunnel reporting success before the connection to the requested target has actually been established.

In the observed case, `DialTCP` returned after sending the tunnel initialization and destination frames. The SOCKS server therefore sent a successful reply to the client before aTrust reported whether the target was reachable. Refused and unreachable targets were incorrectly treated as connected and were only closed afterward.

This caused several user-visible problems:

- SSH entered key exchange and then failed with a generic EOF or connection closure instead of the original connection error
- port scanners and health checks produced false positives
- applications could not distinguish a reachable target from connection refusal or network unreachability
- retry and fallback logic based on the result of `connect()` behaved incorrectly

> Note: This issue is in the aTrust TCP Tunnel and affects callers that rely on the result of `DialTCP`, including the SOCKS5 server. TUN mode also uses the TCP Tunnel for proxied TCP traffic, but its local TCP handshake and error presentation are handled separately.

## Reproduction

Environment where this was observed:

- macOS arm64
- zju-connect v1.2.1
- `protocol = "atrust"`
- `tcp_tunnel_mode = false`
- SOCKS5 listener on `127.0.0.1:1090`
- server address: `vpn.zju.edu.cn:443`

The following targets were used to distinguish the three relevant states:

| Target | Verified state |
| --- | --- |
| `10.10.98.98:443` | reachable |
| `10.130.142.26:2222` | connection refused |
| `10.114.5.14:233` | network unreachable |

You can replace the targets with any equivalent addresses that produce the same three states.

Results:

```shell
➜ nc -X 5 -x 127.0.0.1:1090 -zv 10.10.98.98 443
Connection to 10.10.98.98 port 443 [tcp/https] succeeded!

➜ nc -X 5 -x 127.0.0.1:1090 -zv 10.130.142.26 2222
Connection to 10.130.142.26 port 2222 [tcp/rockwell-csp2] succeeded!

➜ nc -X 5 -x 127.0.0.1:1090 -zv 10.114.5.14 233
Connection to 10.114.5.14 port 233 [tcp/*] succeeded!
```

Expected behavior: only the reachable target should succeed. The refused and unreachable targets should return their corresponding SOCKS5 errors.

Actual behavior before this patch: all three targets were reported as successfully connected.

## Protocol Observation

The observed aTrust TCP Tunnel connection sequence is:

```text
05 81
53 00 | response length | protocol response
01 00 00 00
05 REP
```

The initial `05 81` and `53 00` responses indicate that the tunnel request was accepted, but they do not contain the result of connecting to the requested target.

In the tested environment, sending an empty application-data frame (`01 00 00 00`) triggered the target connection without consuming application payload. The following `05 REP` values matched the corresponding SOCKS5 reply codes:

```text
05 00  target connected
05 03  network unreachable
05 04  host unreachable
05 05  connection refused
...
```

## Changes

This patch:

- reads the initial `05 81` response
- reads and validates the `53 00` protocol response
- sends an empty application-data frame to trigger the target connection
- waits for the `05 REP` connection status before returning from `DialTCP`
- returns meaningful errors for refused, unreachable, and other failure statuses
- closes the underlying connection when tunnel setup or target connection fails

## Verification

After applying the patch, the same three commands produced the expected results:

```shell
➜ nc -X 5 -x 127.0.0.1:1090 -zv 10.10.98.98 443
Connection to 10.10.98.98 port 443 [tcp/https] succeeded!

➜ nc -X 5 -x 127.0.0.1:1090 -zv 10.130.142.26 2222
nc: connection failed, SOCKS error 5

➜ nc -X 5 -x 127.0.0.1:1090 -zv 10.114.5.14 233
nc: connection failed, SOCKS error 3
```

### Runtime Logs

```text
2026/07/22 02:16:24 10.10.98.98:443 -> VPN
2026/07/22 02:16:28 10.130.142.26:2222 -> VPN
[SOCKS5] 2026/07/22 02:16:28 [E]: server: connect to 10.130.142.26:2222 failed, connection refused
2026/07/22 02:16:37 10.114.5.14:233 -> VPN
[SOCKS5] 2026/07/22 02:16:52 [E]: server: connect to 10.114.5.14:233 failed, network is unreachable
```

### Static Verification

```text
go vet ./...
go test ./...
git diff --check
```
