### PR TITLE
fix AUR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
           sed -i "s/^pkgver=.*/pkgver=${PKGVER}/" PKGBUILD
           sed -i "s/^pkgrel=.*/pkgrel=${PKGREL}/" PKGBUILD
 
-          docker run --rm -v "$PWD:/pkg" -w /pkg archlinux:base-devel bash <<'EOF'
+          docker run --rm -i -v "$PWD:/pkg" -w /pkg archlinux:base-devel bash <<'EOF'
           set -euo pipefail
           pacman -Sy --noconfirm pacman-contrib
           useradd -m builder


### PR DESCRIPTION
`-i` 保持容器的 stdin 打开，不然读到 bash 后面的 EOF 脚本就结束了，传递给容器的脚本完全没有运行

目前 AUR 上的包的 `.SRCINFO` 一直停留在 1.0.0