### PR TITLE
fix: preserve aTrust TCP connect errors

### DIFF
--- a/client/atrust/tcptunnel.go
+++ b/client/atrust/tcptunnel.go
@@ -27,6 +27,8 @@ type tcpTunnelConn struct {
 	readBuf []byte
 }
 
+const tcpTunnelSetupTimeout = 18 * time.Second
+
 func readTCPProtocolResponse(reader *bufio.Reader) (string, error) {
 	lengthBytes := make([]byte, 2)
 	if _, err := io.ReadFull(reader, lengthBytes); err != nil {
@@ -39,24 +41,42 @@ func readTCPProtocolResponse(reader *bufio.Reader) (string, error) {
 	return string(data), nil
 }
 
-func waitForTCPConnect(ctx context.Context, conn net.Conn, reader *bufio.Reader) (err error) {
-	if err := ctx.Err(); err != nil {
-		return err
+func readTCPConnectStatus(reader *bufio.Reader) (byte, error) {
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(reader, header); err != nil {
+		return 0, err
+	}
+	if header[0] != 0x05 {
+		return 0, fmt.Errorf("unexpected tcp tunnel connect status: %02X %02X", header[0], header[1])
+	}
+	if header[1] != 0x00 {
+		return header[1], nil
 	}
 
-	cancelDone := make(chan struct{})
-	stopCancel := context.AfterFunc(ctx, func() {
-		defer close(cancelDone)
-		_ = conn.Close()
-	})
-	defer func() {
-		if !stopCancel() {
-			<-cancelDone
+	addressLength := 0
+	switch header[3] {
+	case 0x01:
+		addressLength = net.IPv4len
+	case 0x03:
+		length := make([]byte, 1)
+		if _, err := io.ReadFull(reader, length); err != nil {
+			return 0, err
 		}
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			err = ctxErr
-		}
-	}()
+		addressLength = int(length[0])
+	case 0x04:
+		addressLength = net.IPv6len
+	default:
+		return 0, fmt.Errorf("unexpected tcp tunnel address type: 0x%02X", header[3])
+	}
+
+	addressAndPort := make([]byte, addressLength+2)
+	if _, err := io.ReadFull(reader, addressAndPort); err != nil {
+		return 0, err
+	}
+	return header[1], nil
+}
+
+func waitForTCPConnect(reader *bufio.Reader) error {
 
 	for {
 		header := make([]byte, 2)
@@ -83,25 +103,13 @@ func waitForTCPConnect(ctx context.Context, conn net.Conn, reader *bufio.Reader)
 		break
 	}
 
-	probe := []byte{0x01, 0x00, 0x00, 0x00}
-	if n, err := conn.Write(probe); err != nil {
-		return fmt.Errorf("failed to send tcp tunnel connect probe: %w", err)
-	} else if n != len(probe) {
-		return fmt.Errorf("failed to send tcp tunnel connect probe: %w", io.ErrShortWrite)
-	}
-	log.DebugPrint("Sent TCP connect probe")
-	log.DebugDumpHex(probe)
-
-	status := make([]byte, 2)
-	if _, err := io.ReadFull(reader, status); err != nil {
+	status, err := readTCPConnectStatus(reader)
+	if err != nil {
 		return fmt.Errorf("failed to read tcp tunnel connect status: %w", err)
 	}
-	log.DebugPrint("Received TCP connect status: ", fmt.Sprintf("%02X %02X", status[0], status[1]))
-	if status[0] != 0x05 {
-		return fmt.Errorf("unexpected tcp tunnel connect status: %02X %02X", status[0], status[1])
-	}
+	log.DebugPrint("Received TCP connect status: ", fmt.Sprintf("05 %02X", status))
 
-	switch status[1] {
+	switch status {
 	case 0x00:
 		return nil
 	case 0x01:
@@ -121,15 +129,39 @@ func waitForTCPConnect(ctx context.Context, conn net.Conn, reader *bufio.Reader)
 	case 0x08:
 		return fmt.Errorf("tcp tunnel address type not supported")
 	default:
-		return fmt.Errorf("tcp tunnel connect failed with status 0x%02X", status[1])
+		return fmt.Errorf("tcp tunnel connect failed with status 0x%02X", status)
 	}
 }
 
-func (c *Client) waitForTCPConnect(ctx context.Context, conn net.Conn, reader *bufio.Reader) error {
+func (c *Client) establishTCPConnection(ctx context.Context, conn net.Conn, reader *bufio.Reader, request []byte) (err error) {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	cancelDone := make(chan struct{})
+	stopCancel := context.AfterFunc(ctx, func() {
+		defer close(cancelDone)
+		_ = conn.Close()
+	})
+	defer func() {
+		if !stopCancel() {
+			<-cancelDone
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
+		}
+	}()
+
+	if n, err := conn.Write(request); err != nil {
+		return fmt.Errorf("failed to send tcp tunnel request: %w", err)
+	} else if n != len(request) {
+		return fmt.Errorf("failed to send tcp tunnel request: %w", io.ErrShortWrite)
+	}
+	log.DebugDumpHex(request)
 	if c.skipTCPTunnelWait {
 		return nil
 	}
-	return waitForTCPConnect(ctx, conn, reader)
+	return waitForTCPConnect(reader)
 }
 
 func (c *tcpTunnelConn) Read(b []byte) (int, error) {
@@ -350,11 +382,6 @@ func (c *Client) DialTCP(ctx context.Context, addr *net.TCPAddr) (net.Conn, erro
 	initHeader := []byte{0x05, 0x01, 0x81, 0x53, 0x03}
 	initMsg := append(initHeader, lenBytes...)
 	initMsg = append(initMsg, msgBytes...)
-	if _, err := conn.Write(initMsg); err != nil {
-		_ = conn.Close()
-		return nil, fmt.Errorf("failed to send init message: %w", err)
-	}
-	log.DebugDumpHex(initMsg)
 
 	var destMsg []byte
 	if domain == "" {
@@ -372,19 +399,27 @@ func (c *Client) DialTCP(ctx context.Context, addr *net.TCPAddr) (net.Conn, erro
 		destMsg = append(destHeader, []byte(domain)...)
 	}
 	destMsg = append(destMsg, destPort...)
-	if _, err := conn.Write(destMsg); err != nil {
-		_ = conn.Close()
-		return nil, fmt.Errorf("failed to send dest address: %w", err)
+	initMsg = append(initMsg, destMsg...)
+	deadline := time.Now().Add(tcpTunnelSetupTimeout)
+	if contextDeadline, ok := ctx.Deadline(); ok && contextDeadline.Before(deadline) {
+		deadline = contextDeadline
 	}
-	log.DebugDumpHex(destMsg)
+	if err := conn.SetDeadline(deadline); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to set tcp tunnel deadline: %w", err)
+	}
 
 	tunnelConn := &tcpTunnelConn{
 		tlsConn: conn,
 		reader:  bufio.NewReader(conn),
 	}
-	if err := c.waitForTCPConnect(ctx, conn, tunnelConn.reader); err != nil {
+	if err := c.establishTCPConnection(ctx, conn, tunnelConn.reader, initMsg); err != nil {
 		_ = conn.Close()
 		return nil, err
+	}
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to clear tcp tunnel deadline: %w", err)
 	}
 	return tunnelConn, nil
 }

--- a/client/atrust/tcptunnel.go
+++ b/client/atrust/tcptunnel.go
@@ -117,11 +117,11 @@ func waitForTCPConnect(reader *bufio.Reader) error {
 	case 0x02:
 		return fmt.Errorf("tcp tunnel connection not allowed")
 	case 0x03:
-		return fmt.Errorf("network is unreachable")
+		return client.ErrNetworkUnreachable
 	case 0x04:
-		return fmt.Errorf("host is unreachable")
+		return client.ErrHostUnreachable
 	case 0x05:
-		return fmt.Errorf("connection refused")
+		return client.ErrConnectionRefused
 	case 0x06:
 		return fmt.Errorf("tcp tunnel TTL expired")
 	case 0x07:

--- a/client/atrust/tcptunnel_test.go
+++ b/client/atrust/tcptunnel_test.go
@@ -2,51 +2,24 @@ package atrust
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"net"
 	"strings"
-	"sync"
 	"testing"
 )
 
-func runTCPConnectExchange(t *testing.T, status byte) (error, []byte) {
-	t.Helper()
+var tcpSetupResponse = []byte{0x05, 0x81, 0x53, 0x00, 0x00, 0x02, 'O', 'K'}
 
-	client, server := net.Pipe()
-	t.Cleanup(func() {
-		_ = client.Close()
-		_ = server.Close()
-	})
-
-	probeCh := make(chan []byte, 1)
-	serverErrCh := make(chan error, 1)
-	go func() {
-		setupResponse := []byte{0x05, 0x81, 0x53, 0x00, 0x00, 0x02, 'O', 'K'}
-		for _, value := range setupResponse {
-			if _, err := server.Write([]byte{value}); err != nil {
-				serverErrCh <- err
-				return
-			}
-		}
-
-		probe := make([]byte, 4)
-		if _, err := io.ReadFull(server, probe); err != nil {
-			serverErrCh <- err
-			return
-		}
-		probeCh <- probe
-		_, err := server.Write([]byte{0x05, status})
-		serverErrCh <- err
-	}()
-
-	err := waitForTCPConnect(context.Background(), client, bufio.NewReader(client))
-	probe := <-probeCh
-	if serverErr := <-serverErrCh; serverErr != nil {
-		t.Fatalf("server exchange failed: %v", serverErr)
+func runTCPConnectExchange(status byte) error {
+	response := append([]byte{}, tcpSetupResponse...)
+	response = append(response, 0x05, status, 0x00, 0x01)
+	if status == 0x00 {
+		response = append(response, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
 	}
-	return err, probe
+	return waitForTCPConnect(bufio.NewReader(bytes.NewReader(response)))
 }
 
 func TestWaitForTCPConnectStatus(t *testing.T) {
@@ -69,10 +42,7 @@ func TestWaitForTCPConnectStatus(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err, probe := runTCPConnectExchange(t, test.status)
-			if string(probe) != string([]byte{0x01, 0x00, 0x00, 0x00}) {
-				t.Fatalf("unexpected connect probe: % X", probe)
-			}
+			err := runTCPConnectExchange(test.status)
 			if test.wantErrMsg == "" {
 				if err != nil {
 					t.Fatalf("waitForTCPConnect() error = %v", err)
@@ -86,60 +56,80 @@ func TestWaitForTCPConnectStatus(t *testing.T) {
 	}
 }
 
-type signalingReader struct {
-	io.Reader
-	once    sync.Once
-	started chan struct{}
+func TestReadTCPConnectStatusSuccessReplies(t *testing.T) {
+	tests := []struct {
+		name  string
+		reply []byte
+	}{
+		{name: "IPv4", reply: []byte{0x05, 0x00, 0x00, 0x01, 127, 0, 0, 1, 0x1f, 0x90}},
+		{name: "domain", reply: []byte{0x05, 0x00, 0x00, 0x03, 0x03, 'z', 'j', 'u', 0x01, 0xbb}},
+		{name: "IPv6", reply: []byte{0x05, 0x00, 0x00, 0x04, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 80}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status, err := readTCPConnectStatus(bufio.NewReader(bytes.NewReader(test.reply)))
+			if err != nil {
+				t.Fatalf("readTCPConnectStatus() error = %v", err)
+			}
+			if status != 0x00 {
+				t.Fatalf("readTCPConnectStatus() status = 0x%02X", status)
+			}
+		})
+	}
 }
 
-func (r *signalingReader) Read(p []byte) (int, error) {
-	r.once.Do(func() { close(r.started) })
-	return r.Reader.Read(p)
-}
+func TestEstablishTCPConnectionHonorsContextCancellation(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
 
-func TestWaitForTCPConnectHonorsContextCancellation(t *testing.T) {
-	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
-
-	started := make(chan struct{})
-	reader := bufio.NewReader(&signalingReader{Reader: client, started: started})
-	ctx, cancel := context.WithCancel(context.Background())
-	resultCh := make(chan error, 1)
+	request := []byte{0x05, 0x01, 0x81, 0x05, 0x01, 0x01}
+	requestRead := make(chan struct{})
 	go func() {
-		resultCh <- waitForTCPConnect(ctx, client, reader)
+		_, _ = io.ReadFull(serverConn, make([]byte, len(request)))
+		close(requestRead)
 	}()
 
-	<-started
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	client := &Client{}
+	go func() {
+		resultCh <- client.establishTCPConnection(ctx, clientConn, bufio.NewReader(clientConn), request)
+	}()
+
+	<-requestRead
 	cancel()
 	if err := <-resultCh; !errors.Is(err, context.Canceled) {
-		t.Fatalf("waitForTCPConnect() error = %v, want context.Canceled", err)
+		t.Fatalf("establishTCPConnection() error = %v, want context.Canceled", err)
 	}
 }
 
 func TestWaitForTCPConnectRejectsMalformedResponse(t *testing.T) {
-	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
-
-	go func() {
-		_, _ = server.Write([]byte{0x01, 0x00})
-	}()
-
-	err := waitForTCPConnect(context.Background(), client, bufio.NewReader(client))
+	err := waitForTCPConnect(bufio.NewReader(bytes.NewReader([]byte{0x01, 0x00})))
 	if err == nil || !strings.Contains(err.Error(), "unexpected tcp tunnel response: 01 00") {
 		t.Fatalf("waitForTCPConnect() error = %v", err)
 	}
 }
 
-func TestClientWaitForTCPConnectCanBeSkipped(t *testing.T) {
+func TestEstablishTCPConnectionCanSkipWait(t *testing.T) {
 	clientConn, serverConn := net.Pipe()
 	defer clientConn.Close()
 	defer serverConn.Close()
 
+	request := []byte{0x05, 0x01, 0x81, 0x05, 0x01, 0x01}
+	requestCh := make(chan []byte, 1)
+	go func() {
+		got := make([]byte, len(request))
+		_, _ = io.ReadFull(serverConn, got)
+		requestCh <- got
+	}()
+
 	client := &Client{skipTCPTunnelWait: true}
-	err := client.waitForTCPConnect(context.Background(), clientConn, bufio.NewReader(clientConn))
-	if err != nil {
-		t.Fatalf("waitForTCPConnect() error = %v", err)
+	if err := client.establishTCPConnection(context.Background(), clientConn, bufio.NewReader(clientConn), request); err != nil {
+		t.Fatalf("establishTCPConnection() error = %v", err)
+	}
+	if got := <-requestCh; !bytes.Equal(got, request) {
+		t.Fatalf("request = % X, want % X", got, request)
 	}
 }

--- a/client/atrust/tcptunnel_test.go
+++ b/client/atrust/tcptunnel_test.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"strings"
 	"testing"
+
+	"github.com/mythologyli/zju-connect/client"
 )
 
 var tcpSetupResponse = []byte{0x05, 0x81, 0x53, 0x00, 0x00, 0x02, 'O', 'K'}
@@ -26,14 +28,15 @@ func TestWaitForTCPConnectStatus(t *testing.T) {
 	tests := []struct {
 		name       string
 		status     byte
+		wantErr    error
 		wantErrMsg string
 	}{
 		{name: "connected", status: 0x00},
 		{name: "server failure", status: 0x01, wantErrMsg: "tcp tunnel server failure"},
 		{name: "not allowed", status: 0x02, wantErrMsg: "tcp tunnel connection not allowed"},
-		{name: "network unreachable", status: 0x03, wantErrMsg: "network is unreachable"},
-		{name: "host unreachable", status: 0x04, wantErrMsg: "host is unreachable"},
-		{name: "refused", status: 0x05, wantErrMsg: "connection refused"},
+		{name: "network unreachable", status: 0x03, wantErr: client.ErrNetworkUnreachable, wantErrMsg: "network is unreachable"},
+		{name: "host unreachable", status: 0x04, wantErr: client.ErrHostUnreachable, wantErrMsg: "host is unreachable"},
+		{name: "refused", status: 0x05, wantErr: client.ErrConnectionRefused, wantErrMsg: "connection refused"},
 		{name: "TTL expired", status: 0x06, wantErrMsg: "tcp tunnel TTL expired"},
 		{name: "command unsupported", status: 0x07, wantErrMsg: "tcp tunnel command not supported"},
 		{name: "address type unsupported", status: 0x08, wantErrMsg: "tcp tunnel address type not supported"},
@@ -43,6 +46,9 @@ func TestWaitForTCPConnectStatus(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := runTCPConnectExchange(test.status)
+			if test.wantErr != nil && !errors.Is(err, test.wantErr) {
+				t.Fatalf("waitForTCPConnect() error = %v, want %v", err, test.wantErr)
+			}
 			if test.wantErrMsg == "" {
 				if err != nil {
 					t.Fatalf("waitForTCPConnect() error = %v", err)

--- a/client/client.go
+++ b/client/client.go
@@ -9,7 +9,12 @@ import (
 	"inet.af/netaddr"
 )
 
-var ErrResourceNotFound = errors.New("resource not found")
+var (
+	ErrResourceNotFound   = errors.New("resource not found")
+	ErrNetworkUnreachable = errors.New("network is unreachable")
+	ErrHostUnreachable    = errors.New("host is unreachable")
+	ErrConnectionRefused  = errors.New("connection refused")
+)
 
 type IPResource struct {
 	IPMin       net.IP

--- a/stack/tun/tcplistener.go
+++ b/stack/tun/tcplistener.go
@@ -4,10 +4,14 @@ package tun
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
+	"sync"
+	"time"
 
+	"github.com/mythologyli/zju-connect/client"
 	"github.com/mythologyli/zju-connect/internal/hook_func"
 	"github.com/mythologyli/zju-connect/log"
 	"github.com/mythologyli/zju-connect/resolve"
@@ -22,9 +26,35 @@ import (
 
 const NICID tcpip.NICID = 2
 
+const tcpUnreachableCacheTTL = 2 * time.Minute
+
 type TCPListenerEndpoint struct {
-	tunEndpoint *Endpoint
-	dispatcher  stack.NetworkDispatcher
+	tunEndpoint    *Endpoint
+	dispatcher     stack.NetworkDispatcher
+	unreachableTCP sync.Map
+}
+
+func (ep *TCPListenerEndpoint) isTCPUnreachable(requestID stack.TransportEndpointID) bool {
+	value, ok := ep.unreachableTCP.Load(requestID)
+	if !ok {
+		return false
+	}
+
+	expiresAt := value.(time.Time)
+	if time.Now().Before(expiresAt) {
+		return true
+	}
+
+	ep.unreachableTCP.CompareAndDelete(requestID, expiresAt)
+	return false
+}
+
+func (ep *TCPListenerEndpoint) cacheTCPUnreachable(requestID stack.TransportEndpointID) {
+	expiresAt := time.Now().Add(tcpUnreachableCacheTTL)
+	ep.unreachableTCP.Store(requestID, expiresAt)
+	time.AfterFunc(tcpUnreachableCacheTTL, func() {
+		ep.unreachableTCP.CompareAndDelete(requestID, expiresAt)
+	})
 }
 
 func (ep *TCPListenerEndpoint) ParseHeader(*stack.PacketBuffer) bool {
@@ -118,29 +148,43 @@ func (s *Stack) CreateTCPListener() error {
 
 func (s *Stack) StartTCPListener() {
 	forwarder := tcp.NewForwarder(s.tcpListenerStack, 0, 10000, func(r *tcp.ForwarderRequest) {
-		outboundAddr := r.ID().LocalAddress.String()
-		outboundPort := r.ID().LocalPort
+		requestID := r.ID()
+		outboundAddr := requestID.LocalAddress.String()
+		outboundPort := requestID.LocalPort
 
 		log.DebugPrintf("[tcp listener] new connection to %s:%d", outboundAddr, outboundPort)
+		if s.tcpListenerEndpoint.isTCPUnreachable(requestID) {
+			r.Complete(false)
+			return
+		}
+
+		remoteConn, err := s.dialRemoteTCP(outboundAddr, outboundPort)
+		if err != nil {
+			log.Printf("Error dialing remote TCP %s:%d via tunnel: %v", outboundAddr, outboundPort, err)
+			if errors.Is(err, client.ErrNetworkUnreachable) || errors.Is(err, client.ErrHostUnreachable) {
+				s.tcpListenerEndpoint.cacheTCPUnreachable(requestID)
+				r.Complete(false)
+			} else {
+				r.Complete(true)
+			}
+			return
+		}
 
 		var w waiter.Queue
-		ep, err := r.CreateEndpoint(&w)
-		if err != nil {
+		ep, endpointErr := r.CreateEndpoint(&w)
+		if endpointErr != nil {
+			_ = remoteConn.Close()
 			r.Complete(true)
 			return
 		}
 		r.Complete(false)
 		localConn := gonet.NewTCPConn(&w, ep)
-		go s.handleInboundConn(localConn, outboundAddr, outboundPort)
+		go s.handleInboundConn(localConn, remoteConn)
 	})
 	s.tcpListenerStack.SetTransportProtocolHandler(tcp.ProtocolNumber, forwarder.HandlePacket)
 }
 
-func (s *Stack) handleInboundConn(lConn net.Conn, targetIP string, targetPort uint16) {
-	defer func(lConn net.Conn) {
-		_ = lConn.Close()
-	}(lConn)
-
+func (s *Stack) dialRemoteTCP(targetIP string, targetPort uint16) (net.Conn, error) {
 	domain, resource, ok := s.ipPool.GetDomain(net.ParseIP(targetIP))
 	ctx := context.Background()
 	if ok {
@@ -153,13 +197,15 @@ func (s *Stack) handleInboundConn(lConn net.Conn, targetIP string, targetPort ui
 	log.Printf("%s -> VPN", targetAddr)
 	addr, err := net.ResolveTCPAddr("tcp", targetAddr)
 	if err != nil {
-		return
+		return nil, err
 	}
-	remoteConn, err := s.endpoint.client.DialTCP(ctx, addr)
-	if err != nil {
-		log.Printf("Error dialing remote TCP %s via tunnel: %v", targetAddr, err)
-		return
-	}
+	return s.endpoint.client.DialTCP(ctx, addr)
+}
+
+func (s *Stack) handleInboundConn(lConn, remoteConn net.Conn) {
+	defer func(lConn net.Conn) {
+		_ = lConn.Close()
+	}(lConn)
 	defer func(remoteConn net.Conn) {
 		_ = remoteConn.Close()
 	}(remoteConn)


### PR DESCRIPTION
# fix: preserve aTrust TCP connect errors

Follow-up to #115.

Static analysis of the official aTrust client shows that, when establishing a TCP tunnel, it sends the authentication request and destination request in a single write:

```text
05 01 81
53 03 | auth request length | auth request JSON
05 01 01 | ATYP | destination address | destination port
```

It then waits for:

```text
05 81
53 00 | auth response length | auth response JSON
05 REP | RSV | ATYP | bound address | bound port
```

The previous implementation sent the authentication request and destination request separately, then sent an additional empty application-data frame to obtain the connect status. Although this worked with the current server, the wire behavior differed from the official client and could cause compatibility problems with stricter server-side validation.

Also, #115 made `DialTCP` wait for the remote connect status, but TUN mode still completed the local gVisor TCP handshake before dialing the remote target. As a result, refused and unreachable targets appeared locally as established connections and their errors were only observed after the handshake had completed.

## Changes

### TCP Tunnel

- send the authentication request and destination request in one write, matching the official client flow
- remove the additional empty application-data probe
- read and validate the complete SOCKS5 connect reply before returning from `DialTCP`
- add an 18-second fallback setup timeout, matching the official aTrust client

### TUN Mode

- dial the remote target before completing the local gVisor TCP handshake
- return RST for refused and other immediate failures
- leave network and host unreachable SYNs unanswered so the local TCP stack times out normally
- cache unreachable TCP four-tuples for two minutes to avoid redialing on SYN retransmissions

## Verification

TUN mode verification:

```shell
➜ nc -zv 10.10.98.98 443
Connection to 10.10.98.98 port 443 [tcp/https] succeeded!

➜ nc -zv 10.130.142.26 2222
nc: connectx to 10.130.142.26 port 2222 (tcp) failed: Connection refused

➜ nc -zv 10.114.5.14 233
nc: connectx to 10.114.5.14 port 233 (tcp) failed: Operation timed out
```

Automated checks:

```text
go test ./...
go vet ./...
git diff --check
```