### PR TITLE
impl tls ping to prevent false connectivity test caused by mihomo

### DIFF
--- a/internal/ping/tcp.go
+++ b/internal/ping/tcp.go
@@ -2,6 +2,7 @@ package ping
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"time"
@@ -106,7 +107,17 @@ func (tcping TCPing) ping() (time.Duration, net.Addr, error) {
 			return err
 		}
 		remoteAddr = conn.RemoteAddr()
-		conn.Close()
+		defer conn.Close()
+
+		tlsConn := tls.Client(conn, &tls.Config{
+			ServerName:         tcping.target.Host,
+			InsecureSkipVerify: true,
+		})
+		err = tlsConn.HandshakeContext(ctx)
+		tlsConn.Close()
+		if err != nil {
+			return err
+		}
 		return nil
 	})
 	if errIfce != nil {


### PR DESCRIPTION
close #123
close #122 
启动时加入-tls-ping参数或在配置文件加入tls_ping = true可避免TCP下的误判情况，默认关闭