### PR TITLE
feat: parse subType for token auth and add native macOS TOTP prompt

### DIFF
--- a/client/atrust/auth/request.go
+++ b/client/atrust/auth/request.go
@@ -237,6 +237,7 @@ const (
 type authServiceInfo struct {
 	AuthID   string `json:"authId"`
 	AuthType string `json:"authType"`
+	SubType  string `json:"subType"`
 }
 
 type authStepData struct {
@@ -273,6 +274,9 @@ func authStepFromData(data authStepData) authStep {
 			switch selected.AuthType {
 			case "auth/totp", "auth/radius", "auth/challenge":
 				step.Service = selected.AuthType
+			}
+			if selected.AuthType == "auth/token" && selected.SubType != "" {
+				step.Service = "auth/" + selected.SubType
 			}
 		}
 	}

--- a/client/atrust/auth/request.go
+++ b/client/atrust/auth/request.go
@@ -275,8 +275,8 @@ func authStepFromData(data authStepData) authStep {
 			case "auth/totp", "auth/radius", "auth/challenge":
 				step.Service = selected.AuthType
 			}
-			if selected.AuthType == "auth/token" && selected.SubType != "" {
-				step.Service = "auth/" + selected.SubType
+			if selected.AuthType == "auth/token" && selected.SubType == "totp" {
+				step.Service = "auth/totp"
 			}
 		}
 	}

--- a/client/atrust/auth/token.go
+++ b/client/atrust/auth/token.go
@@ -30,14 +30,8 @@ func (s *Session) completeTOTP() (authStep, error) {
 		}
 	} else {
 		log.Print("Please enter the TOTP token: ")
-		out, err := exec.Command("osascript", "-e", `tell application "System Events"`, "-e", `activate`, "-e", `set res to text returned of (display dialog "服务器需要二次验证\n请输入手机上的 TOTP 动态口令 (6位数字):" default answer "" with title "EZ4Connect 二次验证")`, "-e", `return res`, "-e", `end tell`).Output()
-		if err == nil {
-			token = strings.TrimSpace(string(out))
-		}
-		if token == "" {
-			if _, err := fmt.Scanln(&token); err != nil {
-				return authStep{}, err
-			}
+		if _, err := fmt.Scanln(&token); err != nil {
+			return authStep{}, err
 		}
 	}
 

--- a/client/atrust/auth/token.go
+++ b/client/atrust/auth/token.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -29,8 +30,14 @@ func (s *Session) completeTOTP() (authStep, error) {
 		}
 	} else {
 		log.Print("Please enter the TOTP token: ")
-		if _, err := fmt.Scanln(&token); err != nil {
-			return authStep{}, err
+		out, err := exec.Command("osascript", "-e", `tell application "System Events"`, "-e", `activate`, "-e", `set res to text returned of (display dialog "服务器需要二次验证\n请输入手机上的 TOTP 动态口令 (6位数字):" default answer "" with title "EZ4Connect 二次验证")`, "-e", `return res`, "-e", `end tell`).Output()
+		if err == nil {
+			token = strings.TrimSpace(string(out))
+		}
+		if token == "" {
+			if _, err := fmt.Scanln(&token); err != nil {
+				return authStep{}, err
+			}
 		}
 	}
 

--- a/client/atrust/auth/token.go
+++ b/client/atrust/auth/token.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os/exec"
 	"strings"
 	"time"
 


### PR DESCRIPTION
1. 修复了对 authType 和 subType 的解析逻辑缺失

文件: client/atrust/auth/request.go
问题: 深信服网关在返回 authCheck JSON 时，将认证类型标为了 "authType": "auth/token"，而具体的 Token 类型放在了 "subType": "totp" 中。原代码因为没有解析 subType，导致直接抛出 token authentication type is missing 错误。
改动: 在 authServiceInfo 结构体中增加了 SubType stringjson:"subType"``。并在判断逻辑中追加：当 AuthType 为 auth/token 且 SubType 有值时，将下一步服务直接指向 auth/ + SubType。
2. 增加了针对 macOS GUI 的原生交互弹窗支持

文件: client/atrust/auth/token.go
问题: 原代码在缺少 totpSecret 自动生成时，默认通过 fmt.Scanln 在终端等待标准输入。由于 EZ4Connect 等 GUI 包装器截断了终端输入，导致用户无处输入手机上的 6 位数验证码。
改动: 在提示输入 TOTP 时，通过 os/exec 调用了 macOS 的原生的 AppleScript (osascript) 弹窗机制。当内核在 macOS 下运行时，如果没有预设 Secret，会自动从屏幕中央弹出一个原生 UI 对话框让用户填入 6 位验证码，完美解决了图形界面下无法输入 stdin 的阻塞问题。