### PR TITLE
feat(cli): support reading password from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@
 
 + `password`: 网络账户密码
 
++ `password-file`: 从指定文件读取网络账户密码（默认空）。可避免在进程参数中明文暴露密码，文件内容末尾的换行符会被去除。若同时设置了 `password`，将以 `password-file` 为准
+
 + `graph-code-file`: 图形验证码文件路径。默认为空。在 aTrust 模式下，留空时使用浏览器完成验证码，设置路径则登录时会将图形验证码保存至该文件，由用户手动输入 JSON
 
 + `disable-zju-config`: 禁用 ZJU 相关配置，非 ZJU 用户可能需要添加此参数

--- a/README_en.md
+++ b/README_en.md
@@ -109,6 +109,8 @@
 
 + `password`: Network account password
 
++ `password-file`: Read the network account password from the given file (default empty). This avoids exposing the password in plaintext in process arguments. Trailing newlines in the file are stripped. If both `password` and `password-file` are set, `password-file` takes precedence
+
 + `graph-code-file`: Graphic captcha file path, default is empty. In aTrust mode, if set, the program will save the captcha image to this file and ask user to input the JSON in terminal.
 
 + `disable-zju-config`: Disable ZJU related configuration, non-ZJU users may need to add this argument

--- a/config.toml.example
+++ b/config.toml.example
@@ -3,6 +3,7 @@ server_address = "rvpn.zju.edu.cn"
 server_port = 443
 username = "username"
 password = "password"
+password_file = "" # Read the password from this file instead, e.g. "/run/secrets/vpn_password"
 disable_zju_config = false
 disable_zju_dns = false
 socks_bind = ":1080"

--- a/configs/config.go
+++ b/configs/config.go
@@ -8,6 +8,7 @@ type (
 		ServerPort          int
 		Username            string
 		Password            string
+		PasswordFile        string
 		SocksBind           string
 		SocksUser           string
 		SocksPasswd         string
@@ -79,6 +80,7 @@ type (
 		ServerPort              *int                       `toml:"server_port"`
 		Username                *string                    `toml:"username"`
 		Password                *string                    `toml:"password"`
+		PasswordFile            *string                    `toml:"password_file"`
 		TOTPSecret              *string                    `toml:"totp_secret"`
 		CertFile                *string                    `toml:"cert_file"`
 		CertPassword            *string                    `toml:"cert_password"`

--- a/init.go
+++ b/init.go
@@ -49,6 +49,7 @@ func parseTOMLConfig(configFile string, conf *configs.Config) error {
 	conf.ServerPort = getTOMLVal(confTOML.ServerPort, 443)
 	conf.Username = getTOMLVal(confTOML.Username, "")
 	conf.Password = getTOMLVal(confTOML.Password, "")
+	conf.PasswordFile = getTOMLVal(confTOML.PasswordFile, "")
 	conf.TOTPSecret = getTOMLVal(confTOML.TOTPSecret, "")
 	conf.CertFile = getTOMLVal(confTOML.CertFile, "")
 	conf.CertPassword = getTOMLVal(confTOML.CertPassword, "")
@@ -152,6 +153,7 @@ func init() {
 	flag.IntVar(&conf.ServerPort, "port", 443, "EasyConnect/aTrust port address")
 	flag.StringVar(&conf.Username, "username", "", "Your username")
 	flag.StringVar(&conf.Password, "password", "", "Your password")
+	flag.StringVar(&conf.PasswordFile, "password-file", "", "Read the password from the given file instead of passing it on the command line")
 	flag.StringVar(&conf.TOTPSecret, "totp-secret", "", "TOTP secret")
 	flag.StringVar(&conf.CertFile, "cert-file", "", "Client certificate p12 file path for certificate login")
 	flag.StringVar(&conf.CertPassword, "cert-password", "", "Client certificate password")
@@ -328,6 +330,18 @@ func init() {
 				conf.CustomProxyDomain = append(conf.CustomProxyDomain, domain)
 			}
 		}
+	}
+
+	if conf.PasswordFile != "" {
+		if conf.Password != "" {
+			log.Println("ZJU Connect: both password and password-file are set, password-file will be used")
+		}
+		password, err := os.ReadFile(conf.PasswordFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ZJU Connect: read password file error: %s\n", err)
+			os.Exit(1)
+		}
+		conf.Password = strings.TrimRight(string(password), "\r\n")
 	}
 
 	missing := conf.ServerAddress == ""


### PR DESCRIPTION
## What

Add the `-password-file` CLI flag so the password can be provided via a file instead of being passed in plaintext as a process argument (e.g. `./zju-connect -password-file /run/secrets/vpn_password`). Also supported via the `password_file` key in the TOML config file.

## Behavior

- Trailing newlines (`\r\n`) in the file are stripped before use.
- If both `-password` and `-password-file` are set, a warning is printed and `-password-file` takes precedence.
- A missing/unreadable password file causes a clear error and exit.
- The value is loaded before the required-argument check, so both EasyConnect (`auth/psw`) and aTrust password login work unchanged.

## Files changed

- `init.go` – register the flag, parse `password_file` from TOML, read the file into `conf.Password`
- `configs/config.go` – add `PasswordFile` field to `Config` and `ConfigTOML`
- `config.toml.example` – document the new key
- `README.md` / `README_en.md` – document the new parameter

## Testing

- `go build ./...` and `go vet ./...` pass
- Smoke-tested: password via file starts successfully, nonexistent file errors out clearly, both-set warning works, TOML `password_file` works