### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,4 +264,4 @@
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/image?repos=mythologyli/zju-connect&type=date&legend=top-left)](https://www.star-history.com/?repos=mythologyli%2Fzju-connect&type=date&legend=bottom-right)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mythologyli/zju-connect&type=date&legend=top-left)](https://star-history.dera.page/#mythologyli/zju-connect&type=date&legend=bottom-right)

--- a/README_en.md
+++ b/README_en.md
@@ -247,4 +247,4 @@
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/image?repos=mythologyli/zju-connect&type=date&legend=top-left)](https://www.star-history.com/?repos=mythologyli%2Fzju-connect&type=date&legend=bottom-right)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mythologyli/zju-connect&type=date&legend=top-left)](https://star-history.dera.page/#mythologyli/zju-connect&type=date&legend=bottom-right)


### PR DESCRIPTION
The star history chart in our READMEs is currently broken and does not render anymore. This change restores it so contributors can see the project's growth at a glance. Updated both the Chinese and English READMEs.