### PR TITLE
fix(atrust): return refreshed cookies for existing sessions

### DIFF
--- a/client/atrust/auth/auth.go
+++ b/client/atrust/auth/auth.go
@@ -309,13 +309,8 @@ func (s *Session) completeSMS(step authStep) (authStep, error) {
 }
 
 func (s *Session) Login(method LoginMethod, opts LoginOptions) (LoginResult, error) {
-	sid := ""
 	if len(opts.Cookies) > 0 {
 		for _, cookie := range opts.Cookies {
-			if cookie.Host == s.baseHost && cookie.Scheme == "https" && cookie.Name == "sid" {
-				sid = cookie.Value
-			}
-
 			c := &http.Cookie{
 				Name:  cookie.Name,
 				Value: cookie.Value,
@@ -335,11 +330,15 @@ func (s *Session) Login(method LoginMethod, opts LoginOptions) (LoginResult, err
 	if isLogin == 1 {
 		log.Println("Already logged in")
 		username, err := s.onlineInfo()
+		if err != nil {
+			return LoginResult{}, err
+		}
+		sid, cookies := sessionCookies(s)
 		return LoginResult{
 			Username: username,
 			SID:      sid,
-			Cookies:  opts.Cookies,
-		}, err
+			Cookies:  cookies,
+		}, nil
 	}
 
 	if method == nil {
@@ -378,12 +377,21 @@ func (s *Session) Login(method LoginMethod, opts LoginOptions) (LoginResult, err
 		return LoginResult{}, err
 	}
 
+	sid, cookies := sessionCookies(s)
+	return LoginResult{
+		Username: username,
+		SID:      sid,
+		Cookies:  cookies,
+	}, nil
+}
+
+func sessionCookies(s *Session) (string, []Cookie) {
 	cookies := make([]Cookie, 0)
+	sid := ""
 	for _, cookie := range s.client.Jar.Cookies(&url.URL{Host: s.baseHost, Scheme: "https"}) {
 		if cookie.Name == "sid" {
 			sid = cookie.Value
 		}
-
 		cookies = append(cookies, Cookie{
 			Host:   s.baseHost,
 			Scheme: "https",
@@ -391,10 +399,5 @@ func (s *Session) Login(method LoginMethod, opts LoginOptions) (LoginResult, err
 			Value:  cookie.Value,
 		})
 	}
-
-	return LoginResult{
-		Username: username,
-		SID:      sid,
-		Cookies:  cookies,
-	}, nil
+	return sid, cookies
 }

--- a/client/atrust/auth/session_test.go
+++ b/client/atrust/auth/session_test.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLoginReturnsRefreshedCookiesForExistingSession(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/passport/v1/public/authConfig":
+			cookie, err := r.Cookie("sid")
+			if err != nil || cookie.Value != "stored-session-cookie" {
+				t.Errorf("authConfig sid cookie = %#v, %v", cookie, err)
+			}
+			http.SetCookie(w, &http.Cookie{Name: "sid", Value: "refreshed-session-cookie", Path: "/"})
+			fmt.Fprint(w, "{\"data\":{\"isLogin\":1,\"csrfToken\":\"csrf\"}}")
+		case "/passport/v1/user/onlineInfo":
+			fmt.Fprint(w, "{\"code\":0,\"data\":{\"username\":\"student\"}}")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "https://")
+	session := NewSession(host, nil)
+	result, err := session.Login(nil, LoginOptions{
+		DeviceID: "0123456789abcdef0123456789abcdef",
+		Cookies: []Cookie{{
+			Host:   host,
+			Scheme: "https",
+			Name:   "sid",
+			Value:  "stored-session-cookie",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Login() error = %v", err)
+	}
+	if result.Username != "student" {
+		t.Fatalf("Username = %q, want student", result.Username)
+	}
+	if result.SID != "refreshed-session-cookie" {
+		t.Fatalf("SID = %q, want refreshed-session-cookie", result.SID)
+	}
+
+	var sid string
+	for _, cookie := range result.Cookies {
+		if cookie.Name == "sid" {
+			sid = cookie.Value
+			break
+		}
+	}
+	if sid != "refreshed-session-cookie" {
+		t.Fatalf("returned sid cookie = %q, want refreshed-session-cookie", sid)
+	}
+}


### PR DESCRIPTION
## Summary

When `Session.Login` resumes an already-authenticated aTrust session, `authConfig` may refresh cookies through `Set-Cookie`. The current code still returns the original `LoginOptions.Cookies` and SID, so callers can persist stale session state even though the session cookie jar has already been updated.

This change returns the current cookies and SID from the session cookie jar for both resumed and fresh login paths.

## Test

Adds a regression test where the server accepts `sid=stored-session-cookie`, refreshes it to `sid=refreshed-session-cookie`, and verifies that `LoginResult` exposes the refreshed value.

This is intentionally limited to session result correctness and does not change authentication flow or public API shape.