### PR TITLE
fix(ping): make TCPing cancellation interrupt in-flight probes

### DIFF
--- a/client/atrust/node.go
+++ b/client/atrust/node.go
@@ -54,7 +54,7 @@ func getBestReachableNodes(nodeGroups map[string][]string, dialContext client.Di
 	bestNodes := make(map[string]string)
 	for group, nodes := range nodeGroups {
 		if len(nodes) > 0 {
-			var pingList []ping.TCPing
+			var pingList []*ping.TCPing
 			var chList []<-chan struct{}
 
 			for _, node := range nodes {
@@ -78,7 +78,7 @@ func getBestReachableNodes(nodeGroups map[string][]string, dialContext client.Di
 				}
 				tcping.SetTarget(&target)
 
-				pingList = append(pingList, *tcping)
+				pingList = append(pingList, tcping)
 				ch := tcping.Start()
 				chList = append(chList, ch)
 			}

--- a/client/easyconnect/line.go
+++ b/client/easyconnect/line.go
@@ -17,7 +17,7 @@ func findBestLine(lineList []string, dialContext client.DialContextFunc, keyLogW
 	bestLine := ""
 	bestLatency := int64(0)
 
-	var pingList []ping.TCPing
+	var pingList []*ping.TCPing
 	var chList []<-chan struct{}
 
 	for _, server := range lineList {
@@ -41,7 +41,7 @@ func findBestLine(lineList []string, dialContext client.DialContextFunc, keyLogW
 		}
 		tcping.SetTarget(&target)
 
-		pingList = append(pingList, *tcping)
+		pingList = append(pingList, tcping)
 		ch := tcping.Start()
 		chList = append(chList, ch)
 	}

--- a/internal/ping/tcp.go
+++ b/internal/ping/tcp.go
@@ -108,7 +108,7 @@ func (tcping *TCPing) run(ctx context.Context) {
 		case <-ticker.C:
 		}
 
-		duration, remoteAddr, err := tcping.pingContext(ctx)
+		duration, remoteAddr, err := tcping.ping(ctx)
 		if ctx.Err() != nil {
 			return
 		}
@@ -147,7 +147,7 @@ func (tcping *TCPing) Stop() {
 	}
 }
 
-func (tcping *TCPing) pingContext(parent context.Context) (time.Duration, net.Addr, error) {
+func (tcping *TCPing) ping(parent context.Context) (time.Duration, net.Addr, error) {
 	ctx, cancel := context.WithTimeout(parent, tcping.target.Timeout)
 	defer cancel()
 

--- a/internal/ping/tcp.go
+++ b/internal/ping/tcp.go
@@ -63,11 +63,11 @@ func (tcping *TCPing) Result() *Result {
 
 // Start preserves the historical background-context API.
 func (tcping *TCPing) Start() <-chan struct{} {
-	return tcping.StartContext(context.Background())
+	return tcping.StartWithContext(context.Background())
 }
 
-// StartContext starts the probe loop with caller-owned cancellation.
-func (tcping *TCPing) StartContext(ctx context.Context) <-chan struct{} {
+// StartWithContext starts the probe loop with caller-owned cancellation.
+func (tcping *TCPing) StartWithContext(ctx context.Context) <-chan struct{} {
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/internal/ping/tcp.go
+++ b/internal/ping/tcp.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/mythologyli/zju-connect/client"
@@ -16,9 +17,15 @@ import (
 type TCPing struct {
 	target *Target
 	done   chan struct{}
+	stop   chan struct{}
 	result *Result
 	dial   client.DialContextFunc
 	keyLog io.Writer
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	runMu     sync.Mutex
+	cancelRun context.CancelFunc
 }
 
 // SetDialContext overrides the system dialer used by TCPing.
@@ -35,10 +42,10 @@ var _ Pinger = (*TCPing)(nil)
 
 // NewTCPing return a new TCPing
 func NewTCPing() *TCPing {
-	tcping := TCPing{
+	return &TCPing{
 		done: make(chan struct{}),
+		stop: make(chan struct{}),
 	}
-	return &tcping
 }
 
 // SetTarget set target for TCPing
@@ -50,88 +57,131 @@ func (tcping *TCPing) SetTarget(target *Target) {
 }
 
 // Result return the result
-func (tcping TCPing) Result() *Result {
+func (tcping *TCPing) Result() *Result {
 	return tcping.result
 }
 
-// Start a tcping
-func (tcping TCPing) Start() <-chan struct{} {
-	go func() {
-		t := time.NewTicker(tcping.target.Interval)
-		defer t.Stop()
-		for {
-			select {
-			case <-t.C:
-				if tcping.result.Counter >= tcping.target.Counter && tcping.target.Counter != 0 {
-					tcping.Stop()
-					return
-				}
-				duration, remoteAddr, err := tcping.ping()
-				tcping.result.Counter++
+// Start preserves the historical background-context API.
+func (tcping *TCPing) Start() <-chan struct{} {
+	return tcping.StartContext(context.Background())
+}
 
-				if err != nil {
-					log.DebugPrintf("Ping %s - failed: %s\n", tcping.target, err)
-				} else {
-					log.DebugPrintf("Ping %s(%s) - Connected - time=%s\n", tcping.target, remoteAddr, duration)
-
-					if tcping.result.MinDuration == 0 {
-						tcping.result.MinDuration = duration
-					}
-					if tcping.result.MaxDuration == 0 {
-						tcping.result.MaxDuration = duration
-					}
-					tcping.result.SuccessCounter++
-					if duration > tcping.result.MaxDuration {
-						tcping.result.MaxDuration = duration
-					} else if duration < tcping.result.MinDuration {
-						tcping.result.MinDuration = duration
-					}
-					tcping.result.TotalDuration += duration
-				}
-			case <-tcping.done:
-				return
-			}
-		}
-	}()
+// StartContext starts the probe loop with caller-owned cancellation.
+func (tcping *TCPing) StartContext(ctx context.Context) <-chan struct{} {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	tcping.startOnce.Do(func() {
+		runCtx, cancelRun := context.WithCancel(ctx)
+		tcping.runMu.Lock()
+		tcping.cancelRun = cancelRun
+		tcping.runMu.Unlock()
+		go func() {
+			defer close(tcping.done)
+			defer func() {
+				cancelRun()
+				tcping.runMu.Lock()
+				tcping.cancelRun = nil
+				tcping.runMu.Unlock()
+			}()
+			tcping.run(runCtx)
+		}()
+	})
 	return tcping.done
 }
 
-// Stop the tcping
-func (tcping *TCPing) Stop() {
-	tcping.done <- struct{}{}
+func (tcping *TCPing) run(ctx context.Context) {
+	if tcping.target == nil || tcping.result == nil {
+		return
+	}
+	ticker := time.NewTicker(tcping.target.Interval)
+	defer ticker.Stop()
+	for {
+		if tcping.target.Counter != 0 && tcping.result.Counter >= tcping.target.Counter {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-tcping.stop:
+			return
+		case <-ticker.C:
+		}
+
+		duration, remoteAddr, err := tcping.pingContext(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		tcping.result.Counter++
+		if err != nil {
+			log.DebugPrintf("Ping %s - failed: %s\n", tcping.target, err)
+			continue
+		}
+		log.DebugPrintf("Ping %s(%s) - Connected - time=%s\n", tcping.target, remoteAddr, duration)
+		if tcping.result.MinDuration == 0 {
+			tcping.result.MinDuration = duration
+		}
+		if tcping.result.MaxDuration == 0 {
+			tcping.result.MaxDuration = duration
+		}
+		tcping.result.SuccessCounter++
+		if duration > tcping.result.MaxDuration {
+			tcping.result.MaxDuration = duration
+		} else if duration < tcping.result.MinDuration {
+			tcping.result.MinDuration = duration
+		}
+		tcping.result.TotalDuration += duration
+	}
 }
 
-func (tcping TCPing) ping() (time.Duration, net.Addr, error) {
-	var remoteAddr net.Addr
-	duration, errIfce := timeIt(func() interface{} {
-		ctx, cancel := context.WithTimeout(context.Background(), tcping.target.Timeout)
-		defer cancel()
-		dial := (&net.Dialer{}).DialContext
-		if tcping.dial != nil {
-			dial = tcping.dial
-		}
-		conn, err := dial(ctx, "tcp", fmt.Sprintf("%s:%d", tcping.target.Host, tcping.target.Port))
-		if err != nil {
-			return err
-		}
-		remoteAddr = conn.RemoteAddr()
-		defer conn.Close()
-
-		tlsConn := tls.Client(conn, &tls.Config{
-			ServerName:         tcping.target.Host,
-			InsecureSkipVerify: true,
-			KeyLogWriter:       tcping.keyLog,
-		})
-		err = tlsConn.HandshakeContext(ctx)
-		tlsConn.Close()
-		if err != nil {
-			return err
-		}
-		return nil
+// Stop interrupts the current probe, including an in-flight dial or TLS handshake.
+func (tcping *TCPing) Stop() {
+	tcping.stopOnce.Do(func() {
+		close(tcping.stop)
 	})
-	if errIfce != nil {
-		err := errIfce.(error)
-		return 0, remoteAddr, err
+	tcping.runMu.Lock()
+	cancelRun := tcping.cancelRun
+	tcping.runMu.Unlock()
+	if cancelRun != nil {
+		cancelRun()
 	}
-	return time.Duration(duration), remoteAddr, nil
+}
+
+func (tcping *TCPing) pingContext(parent context.Context) (time.Duration, net.Addr, error) {
+	ctx, cancel := context.WithTimeout(parent, tcping.target.Timeout)
+	defer cancel()
+
+	startedAt := time.Now()
+	dial := (&net.Dialer{}).DialContext
+	if tcping.dial != nil {
+		dial = tcping.dial
+	}
+	conn, err := dial(ctx, "tcp", fmt.Sprintf("%s:%d", tcping.target.Host, tcping.target.Port))
+	if err != nil {
+		return 0, nil, contextError(ctx, err)
+	}
+	defer conn.Close()
+	remoteAddr := conn.RemoteAddr()
+
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName:         tcping.target.Host,
+		InsecureSkipVerify: true,
+		KeyLogWriter:       tcping.keyLog,
+	})
+	stopClose := context.AfterFunc(ctx, func() {
+		_ = tlsConn.Close()
+	})
+	defer stopClose()
+	defer tlsConn.Close()
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		return 0, remoteAddr, contextError(ctx, err)
+	}
+	return time.Since(startedAt), remoteAddr, nil
+}
+
+func contextError(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return err
 }

--- a/internal/ping/tcp_context_test.go
+++ b/internal/ping/tcp_context_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestTCPingStartContextStopsBlockedDial(t *testing.T) {
+func TestTCPingStartWithContextStopsBlockedDial(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	started := make(chan struct{})
@@ -27,7 +27,7 @@ func TestTCPingStartContextStopsBlockedDial(t *testing.T) {
 		return nil, ctx.Err()
 	})
 
-	done := tcping.StartContext(ctx)
+	done := tcping.StartWithContext(ctx)
 	select {
 	case <-started:
 	case <-time.After(time.Second):

--- a/internal/ping/tcp_context_test.go
+++ b/internal/ping/tcp_context_test.go
@@ -1,0 +1,89 @@
+package ping
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestTCPingStartContextStopsBlockedDial(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan struct{})
+	tcping := NewTCPing()
+	tcping.SetTarget(&Target{
+		Protocol: TCP,
+		Host:     "node.example.test",
+		Port:     443,
+		Counter:  1,
+		Interval: time.Millisecond,
+		Timeout:  time.Minute,
+	})
+	tcping.SetDialContext(func(ctx context.Context, _, _ string) (net.Conn, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	done := tcping.StartContext(ctx)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("probe never started its dial")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("probe did not stop after context cancellation")
+	}
+	if result := tcping.Result(); result.Counter != 0 || result.SuccessCounter != 0 {
+		t.Fatalf("cancelled probe result = %+v, want no completed attempt", result)
+	}
+}
+
+func TestTCPingStopInterruptsBlockedDial(t *testing.T) {
+	started := make(chan struct{})
+	dialCancelled := make(chan error, 1)
+	tcping := NewTCPing()
+	tcping.SetTarget(&Target{
+		Protocol: TCP,
+		Host:     "node.example.test",
+		Port:     443,
+		Counter:  1,
+		Interval: time.Millisecond,
+		Timeout:  time.Minute,
+	})
+	tcping.SetDialContext(func(ctx context.Context, _, _ string) (net.Conn, error) {
+		close(started)
+		<-ctx.Done()
+		dialCancelled <- ctx.Err()
+		return nil, ctx.Err()
+	})
+
+	done := tcping.Start()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("probe never started its dial")
+	}
+	tcping.Stop()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("probe did not stop")
+	}
+	if result := tcping.Result(); result.Counter != 0 || result.SuccessCounter != 0 {
+		t.Fatalf("stopped probe result = %+v, want no completed attempt", result)
+	}
+	select {
+	case err := <-dialCancelled:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("dial context error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocked dial did not observe Stop cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

`TCPing.Stop()` previously only stopped the probe loop between attempts. If a TCP dial or TLS handshake was already in progress, shutdown could remain blocked until the probe timeout expired.

This change makes probe execution context-aware so cancellation can interrupt an in-flight dial or TLS handshake immediately.

## Changes

- add `StartContext` while preserving the existing `Start()` API
- propagate cancellation into TCP dialing and TLS handshakes
- make `Stop()` cancel the current probe as well as the loop
- add regression tests for both caller context cancellation and `Stop()` during a blocked dial

## Scope

This is limited to the shared `internal/ping` implementation and does not change higher-level VPN or Android behavior.