### PR TITLE
feat(atrust): allow caller-owned TLS config

### DIFF
--- a/client/atrust/auth/auth.go
+++ b/client/atrust/auth/auth.go
@@ -111,21 +111,39 @@ type Session struct {
 	challengeHandler authchallenge.Handler
 }
 
+type SessionOptions struct {
+	TLSConfig       *tls.Config
+	TLSKeyLogWriter io.Writer
+	DialContext     client.DialContextFunc
+}
+
 func NewSession(server string, tlsKeyLogWriter io.Writer, dialContext ...client.DialContextFunc) *Session {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-			KeyLogWriter:       tlsKeyLogWriter,
-		},
+	options := SessionOptions{TLSKeyLogWriter: tlsKeyLogWriter}
+	if len(dialContext) > 0 {
+		options.DialContext = dialContext[0]
 	}
-	if len(dialContext) > 0 && dialContext[0] != nil {
-		tr.DialContext = dialContext[0]
+	return NewSessionWithOptions(server, options)
+}
+
+func NewSessionWithOptions(server string, options SessionOptions) *Session {
+	tlsConfig := options.TLSConfig
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{InsecureSkipVerify: true}
+	} else {
+		tlsConfig = tlsConfig.Clone()
+	}
+	if options.TLSKeyLogWriter != nil {
+		tlsConfig.KeyLogWriter = options.TLSKeyLogWriter
+	}
+	tr := &http.Transport{TLSClientConfig: tlsConfig}
+	if options.DialContext != nil {
+		tr.DialContext = options.DialContext
 	}
 	jar, _ := cookiejar.New(nil)
-	client := &http.Client{Transport: tr, Jar: jar, Timeout: 20 * time.Second}
+	httpClient := &http.Client{Transport: tr, Jar: jar, Timeout: 20 * time.Second}
 
 	return &Session{
-		client:   client,
+		client:   httpClient,
 		baseHost: server,
 		baseURL:  "https://" + server,
 		rid:      base64.StdEncoding.EncodeToString([]byte(server)),

--- a/client/atrust/auth/session_options_test.go
+++ b/client/atrust/auth/session_options_test.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+)
+
+func sessionTransportTLSConfig(t *testing.T, session *Session) *tls.Config {
+	t.Helper()
+	transport, ok := session.client.Transport.(*http.Transport)
+	if !ok || transport.TLSClientConfig == nil {
+		t.Fatal("session transport does not expose TLS config")
+	}
+	return transport.TLSClientConfig
+}
+
+func TestNewSessionPreservesCompatibilityTLSDefault(t *testing.T) {
+	got := sessionTransportTLSConfig(t, NewSession("vpn.example", nil))
+	if !got.InsecureSkipVerify {
+		t.Fatal("NewSession must preserve the existing insecure appliance-compatible default")
+	}
+}
+
+func TestNewSessionWithOptionsClonesCallerTLSConfig(t *testing.T) {
+	original := &tls.Config{ServerName: "vpn.example"}
+	session := NewSessionWithOptions("vpn.example", SessionOptions{TLSConfig: original})
+	original.ServerName = "mutated.example"
+	got := sessionTransportTLSConfig(t, session)
+	if got.ServerName != "vpn.example" {
+		t.Fatalf("caller mutation leaked into session TLS config: %q", got.ServerName)
+	}
+	if got.InsecureSkipVerify {
+		t.Fatal("caller TLS policy was overwritten by compatibility defaults")
+	}
+}

--- a/client/atrust/client.go
+++ b/client/atrust/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/md5"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -35,6 +36,8 @@ type ClientOptions struct {
 	Session         SessionOptions
 	UnderlayDialer  client.UnderlayDialer
 	TLSKeyLogWriter io.Writer
+	AuthTLSConfig   *tls.Config
+	NodeTLSConfig   *tls.Config
 }
 
 type SetupOptions struct {
@@ -83,6 +86,8 @@ type Client struct {
 	closeOnce        sync.Once
 	underlayDialer   client.UnderlayDialer
 	tlsKeyLogWriter  io.Writer
+	authTLSConfig    *tls.Config
+	nodeTLSConfig    *tls.Config
 	tcpTunnelZeroRTT bool
 }
 
@@ -95,6 +100,8 @@ func NewClient(options ClientOptions) *Client {
 		SignKey:         options.Session.SignKey,
 		underlayDialer:  options.UnderlayDialer,
 		tlsKeyLogWriter: options.TLSKeyLogWriter,
+		authTLSConfig:   cloneTLSConfig(options.AuthTLSConfig),
+		nodeTLSConfig:   cloneTLSConfig(options.NodeTLSConfig),
 		lifecycleCtx:    lifecycleCtx,
 		lifecycleCancel: lifecycleCancel,
 	}
@@ -334,7 +341,11 @@ func (c *Client) Setup(options SetupOptions) ([]byte, error) {
 	} else {
 		authServerHost = fmt.Sprintf("%s:%d", options.ServerAddress, options.ServerPort)
 	}
-	sess := auth.NewSession(authServerHost, c.tlsKeyLogWriter, c.underlayDialer.DialContext)
+	sess := auth.NewSessionWithOptions(authServerHost, auth.SessionOptions{
+		TLSConfig:       c.authTLSConfig,
+		TLSKeyLogWriter: c.tlsKeyLogWriter,
+		DialContext:     c.underlayDialer.DialContext,
+	})
 	serverVersionInfo, manifestErr := sess.ServerVersionInfo()
 	serverVersionInfo, err := resolveServerVersionInfo(clientAuthData.ServerVersionInfo, serverVersionInfo, manifestErr)
 	if err != nil {
@@ -404,7 +415,7 @@ func (c *Client) Setup(options SetupOptions) ([]byte, error) {
 
 	log.DebugPrintf("SID: %s, DeviceID: %s, ConnectionID: %s, SignKey: %s", c.SID, c.DeviceID, c.ConnectionID, c.SignKey)
 
-	c.BestNodes = getBestNodes(c.NodeGroups, c.underlayDialer.DialContext, c.tlsKeyLogWriter)
+	c.BestNodes = getBestNodes(c.NodeGroups, c.underlayDialer.DialContext, c.tlsKeyLogWriter, c.nodeTLSConfig)
 
 	err = c.getIP()
 	if err != nil {

--- a/client/atrust/ip.go
+++ b/client/atrust/ip.go
@@ -94,7 +94,7 @@ func (c *Client) getIP() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	conn, err := dialTLSContext(ctx, c.underlayDialer, "tcp", addr, tunnelTLSConfig(c.tlsKeyLogWriter))
+	conn, err := dialTLSContext(ctx, c.underlayDialer, "tcp", addr, c.nodeTLSConfigForDial(nil))
 	if err != nil {
 		return err
 	}

--- a/client/atrust/l3tunnel.go
+++ b/client/atrust/l3tunnel.go
@@ -63,7 +63,7 @@ func NewL3Tunnel(aTrustClient *Client) (*L3Tunnel, error) {
 			username:     aTrustClient.Username,
 		}
 		dialTLS := func(ctx context.Context, network, address string, config *tls.Config) (*tls.Conn, error) {
-			return dialTLSContext(ctx, aTrustClient.underlayDialer, network, address, tlsConfig(config, aTrustClient.tlsKeyLogWriter))
+			return dialTLSContext(ctx, aTrustClient.underlayDialer, network, address, aTrustClient.nodeTLSConfigForDial(config))
 		}
 		return newL3TunnelConn(ctx, dialTLS, addr, info, aTrustClient.SignKey, conntrackMgr, t.updateVIP)
 	}

--- a/client/atrust/node.go
+++ b/client/atrust/node.go
@@ -2,6 +2,7 @@ package atrust
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"strconv"
 	"strings"
@@ -21,9 +22,9 @@ type NodeGroup struct {
 
 type nodeGroupsProbeFunc func(map[string][]string) map[string]string
 
-func getBestNodes(nodeGroups map[string]NodeGroup, dialContext client.DialContextFunc, keyLogWriter io.Writer) map[string]string {
+func getBestNodes(nodeGroups map[string]NodeGroup, dialContext client.DialContextFunc, keyLogWriter io.Writer, nodeTLSConfig *tls.Config) map[string]string {
 	return selectBestNodes(nodeGroups, func(nodeGroups map[string][]string) map[string]string {
-		return getBestReachableNodes(nodeGroups, dialContext, keyLogWriter)
+		return getBestReachableNodes(nodeGroups, dialContext, keyLogWriter, nodeTLSConfig)
 	})
 }
 
@@ -50,7 +51,7 @@ func selectBestNodes(nodeGroups map[string]NodeGroup, probe nodeGroupsProbeFunc)
 	return bestNodes
 }
 
-func getBestReachableNodes(nodeGroups map[string][]string, dialContext client.DialContextFunc, keyLogWriter io.Writer) map[string]string {
+func getBestReachableNodes(nodeGroups map[string][]string, dialContext client.DialContextFunc, keyLogWriter io.Writer, nodeTLSConfig *tls.Config) map[string]string {
 	bestNodes := make(map[string]string)
 	for group, nodes := range nodeGroups {
 		if len(nodes) > 0 {
@@ -68,6 +69,7 @@ func getBestReachableNodes(nodeGroups map[string][]string, dialContext client.Di
 				tcping := ping.NewTCPing()
 				tcping.SetDialContext(dialContext)
 				tcping.SetKeyLogWriter(keyLogWriter)
+				tcping.SetTLSConfig(nodeTLSConfig)
 				target := ping.Target{
 					Protocol: ping.TCP,
 					Host:     host,
@@ -130,7 +132,7 @@ func (c *Client) updateBestNodes(ctx context.Context, interval time.Duration) {
 		case <-ticker.C:
 		}
 
-		bestNodes := getBestNodes(c.NodeGroups, c.underlayDialer.DialContext, c.tlsKeyLogWriter)
+		bestNodes := getBestNodes(c.NodeGroups, c.underlayDialer.DialContext, c.tlsKeyLogWriter, c.nodeTLSConfig)
 		c.BestNodesRWMutex.Lock()
 		c.BestNodes = bestNodes
 		c.BestNodesRWMutex.Unlock()

--- a/client/atrust/tcptunnel.go
+++ b/client/atrust/tcptunnel.go
@@ -510,7 +510,7 @@ func (c *Client) DialTCP(ctx context.Context, addr *net.TCPAddr) (net.Conn, erro
 	if nodeAddr == "" {
 		return nil, fmt.Errorf("no available aTrust node for group %q", nodeGroupID)
 	}
-	conn, err := dialTLSContext(ctx, c.underlayDialer, "tcp", nodeAddr, tunnelTLSConfig(c.tlsKeyLogWriter))
+	conn, err := dialTLSContext(ctx, c.underlayDialer, "tcp", nodeAddr, c.nodeTLSConfigForDial(nil))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to aTrust server: %w", err)
 	}

--- a/client/atrust/tls.go
+++ b/client/atrust/tls.go
@@ -10,6 +10,13 @@ import (
 	"github.com/mythologyli/zju-connect/client"
 )
 
+func cloneTLSConfig(config *tls.Config) *tls.Config {
+	if config == nil {
+		return nil
+	}
+	return config.Clone()
+}
+
 func tlsConfig(config *tls.Config, keyLogWriter io.Writer) *tls.Config {
 	if config == nil {
 		config = &tls.Config{}
@@ -28,6 +35,22 @@ func tunnelTLSConfig(keyLogWriter io.Writer) *tls.Config {
 		InsecureSkipVerify:     true,
 		SessionTicketsDisabled: true,
 	}, keyLogWriter)
+}
+
+func (c *Client) nodeTLSConfigForDial(base *tls.Config) *tls.Config {
+	if c != nil && c.nodeTLSConfig != nil {
+		return tlsConfig(c.nodeTLSConfig, c.tlsKeyLogWriter)
+	}
+	if base != nil {
+		if c == nil {
+			return tlsConfig(base, nil)
+		}
+		return tlsConfig(base, c.tlsKeyLogWriter)
+	}
+	if c == nil {
+		return tunnelTLSConfig(nil)
+	}
+	return tunnelTLSConfig(c.tlsKeyLogWriter)
 }
 
 func dialTLSContext(ctx context.Context, dialer client.UnderlayDialer, network, address string, config *tls.Config) (*tls.Conn, error) {

--- a/client/atrust/tls_config_test.go
+++ b/client/atrust/tls_config_test.go
@@ -1,0 +1,28 @@
+package atrust
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNodeTLSConfigDefaultsToOfficialClientPolicy(t *testing.T) {
+	c := NewClient(ClientOptions{})
+	got := c.nodeTLSConfigForDial(nil)
+	if !got.InsecureSkipVerify || !got.SessionTicketsDisabled {
+		t.Fatalf("unexpected default node TLS config: %+v", got)
+	}
+}
+
+func TestNodeTLSConfigIsCloned(t *testing.T) {
+	original := &tls.Config{InsecureSkipVerify: true, ServerName: "node.example"}
+	c := NewClient(ClientOptions{NodeTLSConfig: original})
+	original.ServerName = "mutated.example"
+	first := c.nodeTLSConfigForDial(nil)
+	if first.ServerName != "node.example" {
+		t.Fatalf("caller mutation leaked: %q", first.ServerName)
+	}
+	first.ServerName = "returned.example"
+	if got := c.nodeTLSConfigForDial(nil).ServerName; got != "node.example" {
+		t.Fatalf("returned mutation leaked: %q", got)
+	}
+}

--- a/internal/ping/tcp.go
+++ b/internal/ping/tcp.go
@@ -15,12 +15,13 @@ import (
 
 // TCPing ...
 type TCPing struct {
-	target *Target
-	done   chan struct{}
-	stop   chan struct{}
-	result *Result
-	dial   client.DialContextFunc
-	keyLog io.Writer
+	target    *Target
+	done      chan struct{}
+	stop      chan struct{}
+	result    *Result
+	dial      client.DialContextFunc
+	keyLog    io.Writer
+	tlsConfig *tls.Config
 
 	startOnce sync.Once
 	stopOnce  sync.Once
@@ -36,6 +37,28 @@ func (tcping *TCPing) SetDialContext(dial client.DialContextFunc) {
 // SetKeyLogWriter records probe TLS secrets in NSS key log format.
 func (tcping *TCPing) SetKeyLogWriter(writer io.Writer) {
 	tcping.keyLog = writer
+}
+
+func (tcping *TCPing) SetTLSConfig(config *tls.Config) {
+	if config == nil {
+		tcping.tlsConfig = nil
+		return
+	}
+	tcping.tlsConfig = config.Clone()
+}
+
+func (tcping *TCPing) tlsConfigForTarget() *tls.Config {
+	if tcping.tlsConfig == nil {
+		return &tls.Config{ServerName: tcping.target.Host, InsecureSkipVerify: true, KeyLogWriter: tcping.keyLog}
+	}
+	config := tcping.tlsConfig.Clone()
+	if config.ServerName == "" {
+		config.ServerName = tcping.target.Host
+	}
+	if tcping.keyLog != nil {
+		config.KeyLogWriter = tcping.keyLog
+	}
+	return config
 }
 
 var _ Pinger = (*TCPing)(nil)
@@ -163,11 +186,7 @@ func (tcping *TCPing) ping(parent context.Context) (time.Duration, net.Addr, err
 	defer conn.Close()
 	remoteAddr := conn.RemoteAddr()
 
-	tlsConn := tls.Client(conn, &tls.Config{
-		ServerName:         tcping.target.Host,
-		InsecureSkipVerify: true,
-		KeyLogWriter:       tcping.keyLog,
-	})
+	tlsConn := tls.Client(conn, tcping.tlsConfigForTarget())
 	stopClose := context.AfterFunc(ctx, func() {
 		_ = tlsConn.Close()
 	})

--- a/internal/ping/tcp_tls_config_test.go
+++ b/internal/ping/tcp_tls_config_test.go
@@ -1,0 +1,20 @@
+package ping
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestTCPingTLSConfigDefaultAndClone(t *testing.T) {
+	p := NewTCPing()
+	p.SetTarget(&Target{Host: "node.example"})
+	if got := p.tlsConfigForTarget(); !got.InsecureSkipVerify || got.ServerName != "node.example" {
+		t.Fatalf("unexpected default TLS config: %+v", got)
+	}
+	custom := &tls.Config{InsecureSkipVerify: true, ServerName: "pinned.example"}
+	p.SetTLSConfig(custom)
+	custom.ServerName = "mutated.example"
+	if got := p.tlsConfigForTarget().ServerName; got != "pinned.example" {
+		t.Fatalf("TLS config was not cloned: %q", got)
+	}
+}


### PR DESCRIPTION
This adds optional caller-owned TLS config for aTrust auth and data-plane connections while keeping the current default behavior unchanged.

Why: Android/mobile callers may need their own trust policy (for example SPKI verification) without hardcoding deployment-specific policy in zju-connect.

Changes:
- add `auth.SessionOptions` / `NewSessionWithOptions` with optional TLS config
- add `AuthTLSConfig` and `NodeTLSConfig` to `atrust.ClientOptions`
- clone caller configs before use
- apply node TLS policy consistently to node probing, IP acquisition, L3 tunnel and TCP tunnel
- keep nil/default behavior compatible with the current client
- add focused TLS config tests

I also validated this from the Android consumer side: Go tests/vet, gomobile AAR, Android release unit tests, lint and unsigned APK build all pass with the caller-owned portal/node policies wired in.

This deliberately keeps actual ZJU SPKI pins and app policy out of upstream.