### PR TITLE
feat(atrust): add caller-owned setup context

### DIFF
--- a/client/atrust/auth/auth.go
+++ b/client/atrust/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -91,6 +92,7 @@ func (i ServerVersionInfo) TCPTunnelZeroRTT() bool {
 }
 
 type Session struct {
+	ctx        context.Context
 	client     *http.Client
 	deviceID   string
 	username   string
@@ -112,6 +114,13 @@ type Session struct {
 }
 
 func NewSession(server string, tlsKeyLogWriter io.Writer, dialContext ...client.DialContextFunc) *Session {
+	return NewSessionContext(context.Background(), server, tlsKeyLogWriter, dialContext...)
+}
+
+func NewSessionContext(ctx context.Context, server string, tlsKeyLogWriter io.Writer, dialContext ...client.DialContextFunc) *Session {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
@@ -122,15 +131,24 @@ func NewSession(server string, tlsKeyLogWriter io.Writer, dialContext ...client.
 		tr.DialContext = dialContext[0]
 	}
 	jar, _ := cookiejar.New(nil)
-	client := &http.Client{Transport: tr, Jar: jar, Timeout: 20 * time.Second}
+	httpClient := &http.Client{Transport: tr, Jar: jar, Timeout: 20 * time.Second}
 
 	return &Session{
-		client:   client,
+		ctx:      ctx,
+		client:   httpClient,
 		baseHost: server,
 		baseURL:  "https://" + server,
 		rid:      base64.StdEncoding.EncodeToString([]byte(server)),
 		response: make(map[string]json.RawMessage),
 	}
+}
+
+func (s *Session) do(req *http.Request) (*http.Response, error) {
+	ctx := s.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.client.Do(req.WithContext(ctx))
 }
 
 type AuthInfo struct {

--- a/client/atrust/auth/cas.go
+++ b/client/atrust/auth/cas.go
@@ -103,7 +103,7 @@ func (s *Session) cas(callback string) error {
 	}
 	defer func() { s.client.CheckRedirect = prevCheckRedirect }()
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return err
 	}

--- a/client/atrust/auth/custom_sms.go
+++ b/client/atrust/auth/custom_sms.go
@@ -54,7 +54,7 @@ func (s *Session) sendCustomSMS() error {
 	}
 	s.setAuthJSONHeaders(req)
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func (s *Session) customSMSCheckCode(code string, skipSecondaryAuth bool) (authS
 	}
 	s.setAuthJSONHeaders(req)
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return authStep{}, err
 	}

--- a/client/atrust/auth/device.go
+++ b/client/atrust/auth/device.go
@@ -29,7 +29,7 @@ func (s *Session) QueryDevice() (*QueryDeviceResult, error) {
 	req.Header.Set("x-csrf-token", s.csrfToken)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (s *Session) TrustDevice(idList []string) error {
 	req.Header.Set("x-csrf-token", s.csrfToken)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (s *Session) UntrustDevice(idList []string) error {
 	req.Header.Set("x-csrf-token", s.csrfToken)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return err
 	}

--- a/client/atrust/auth/enhanced.go
+++ b/client/atrust/auth/enhanced.go
@@ -59,7 +59,7 @@ func (s *Session) requestAuthStep(method string, step authStep, body []byte) (au
 		req.Header.Set("Content-Type", "application/json;charset=utf-8")
 	}
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return authStep{}, err
 	}

--- a/client/atrust/auth/https_oauth2.go
+++ b/client/atrust/auth/https_oauth2.go
@@ -109,7 +109,7 @@ func (s *Session) httpsOauth2(callback string) error {
 	}
 	defer func() { s.client.CheckRedirect = prevCheckRedirect }()
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return err
 	}

--- a/client/atrust/auth/psw.go
+++ b/client/atrust/auth/psw.go
@@ -81,7 +81,7 @@ func (s *Session) pswImpl(username, password, loginDomain, graphCheckCode string
 	req.Header.Set("x-sdp-env", s.env)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return 0, err
 	}

--- a/client/atrust/auth/request.go
+++ b/client/atrust/auth/request.go
@@ -25,7 +25,7 @@ func (s *Session) ServerVersionInfo() ([]byte, error) {
 	}
 	req.Header.Set("User-Agent", UserAgent)
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (s *Session) authConfig(mod, needTicket bool) (int, []AuthInfo, error) {
 	req.Header.Set("x-sdp-rid", s.rid)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -156,7 +156,7 @@ func (s *Session) performAntiMITMRequest(data antiMITMAttackData, csrfToken stri
 	req.Header.Set("x-sdp-rid", s.rid)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return fmt.Errorf("aTrust anti-MITM request failed: %w", err)
 	}
@@ -227,7 +227,7 @@ func (s *Session) reportEnv() error {
 	req.Header.Set("x-csrf-token", s.csrfToken)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return err
 	}
@@ -342,7 +342,7 @@ func (s *Session) authCheck() (authStep, error) {
 	req.Header.Set("x-csrf-token", s.csrfToken)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return authStep{}, err
 	}
@@ -383,7 +383,7 @@ func (s *Session) phoneNumber(authID string) ([]string, error) {
 	req.Header.Set("x-csrf-token", s.csrfToken)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +465,7 @@ func (s *Session) authSms(step authStep) error {
 	req.Header.Set("x-csrf-token", s.csrfToken)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return err
 	}
@@ -554,7 +554,7 @@ func (s *Session) secondarySMSCheckCodeImpl(step authStep, code string, skipSeco
 	req.Header.Set("x-csrf-token", s.csrfToken)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return authStep{}, err
 	}
@@ -592,7 +592,7 @@ func (s *Session) onlineInfo() (string, error) {
 	req.Header.Set("x-csrf-token", s.csrfToken)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return "", err
 	}
@@ -645,7 +645,7 @@ func (s *Session) ClientResource() ([]byte, error) {
 	req.Header.Set("x-csrf-token", s.csrfToken)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -669,7 +669,7 @@ func (s *Session) checkCode() ([]byte, error) {
 	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Set("Accept", "image/webp,image/apng,image/*,*/*;q=0.8")
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/client/atrust/auth/session_context_test.go
+++ b/client/atrust/auth/session_context_test.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type blockingRoundTripper struct{}
+
+func (blockingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
+func TestNewSessionContextCancelsRequest(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	session := NewSessionContext(ctx, "vpn.example", nil)
+	session.client.Transport = blockingRoundTripper{}
+	req, err := http.NewRequest(http.MethodGet, "https://example.invalid", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := session.do(req)
+		done <- err
+	}()
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("request did not observe session cancellation")
+	}
+}

--- a/client/atrust/auth/sms_check_code.go
+++ b/client/atrust/auth/sms_check_code.go
@@ -78,7 +78,7 @@ func (s *Session) sendSms(phone, loginDomain, graphCheckCode string) (int, error
 	req.Header.Set("x-sdp-env", s.env)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return 0, err
 	}
@@ -133,7 +133,7 @@ func (s *Session) smsCheckCodeImpl(code, phone, loginDomain, graphCheckCode stri
 	req.Header.Set("x-sdp-env", s.env)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return 0, err
 	}

--- a/client/atrust/auth/token.go
+++ b/client/atrust/auth/token.go
@@ -108,7 +108,7 @@ func (s *Session) submitTokenAt(service string, payload map[string]interface{}) 
 	req.Header.Set("x-sdp-env", s.env)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return authStep{}, err
 	}
@@ -140,7 +140,7 @@ func (s *Session) accessCheck() (authStep, error) {
 	req.Header.Set("x-csrf-token", s.csrfToken)
 	req.Header.Set("x-sdp-traceid", s.randSdpId())
 
-	resp, err := s.client.Do(req)
+	resp, err := s.do(req)
 	if err != nil {
 		return authStep{}, err
 	}

--- a/client/atrust/client.go
+++ b/client/atrust/client.go
@@ -311,6 +311,20 @@ func SetTrusted(serverAddress string, serverPort int, authData []byte, trusted b
 }
 
 func (c *Client) Setup(options SetupOptions) ([]byte, error) {
+	return c.SetupContext(context.Background(), options)
+}
+
+func (c *Client) SetupContext(ctx context.Context, options SetupOptions) ([]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	setupCtx, cancelSetup := context.WithCancel(ctx)
+	defer cancelSetup()
+	stopLifecycleCancellation := context.AfterFunc(c.lifecycleCtx, cancelSetup)
+	defer stopLifecycleCancellation()
+	if err := setupCtx.Err(); err != nil {
+		return nil, err
+	}
 	if c.underlayDialer == nil {
 		return nil, errors.New("underlay dialer is required")
 	}
@@ -334,7 +348,7 @@ func (c *Client) Setup(options SetupOptions) ([]byte, error) {
 	} else {
 		authServerHost = fmt.Sprintf("%s:%d", options.ServerAddress, options.ServerPort)
 	}
-	sess := auth.NewSession(authServerHost, c.tlsKeyLogWriter, c.underlayDialer.DialContext)
+	sess := auth.NewSessionContext(setupCtx, authServerHost, c.tlsKeyLogWriter, c.underlayDialer.DialContext)
 	serverVersionInfo, manifestErr := sess.ServerVersionInfo()
 	serverVersionInfo, err := resolveServerVersionInfo(clientAuthData.ServerVersionInfo, serverVersionInfo, manifestErr)
 	if err != nil {
@@ -404,14 +418,20 @@ func (c *Client) Setup(options SetupOptions) ([]byte, error) {
 
 	log.DebugPrintf("SID: %s, DeviceID: %s, ConnectionID: %s, SignKey: %s", c.SID, c.DeviceID, c.ConnectionID, c.SignKey)
 
-	c.BestNodes = getBestNodes(c.NodeGroups, c.underlayDialer.DialContext, c.tlsKeyLogWriter)
+	c.BestNodes = getBestNodes(setupCtx, c.NodeGroups, c.underlayDialer.DialContext, c.tlsKeyLogWriter)
+	if err := setupCtx.Err(); err != nil {
+		return nil, err
+	}
 
-	err = c.getIP()
+	err = c.getIP(setupCtx)
 	if err != nil {
 		return nil, err
 	}
 	c.underlayDialer.ExcludeIP(c.ip)
 
+	if err := setupCtx.Err(); err != nil {
+		return nil, err
+	}
 	l3Tunnel, err := NewL3Tunnel(c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create L3 tunnel: %v", err)

--- a/client/atrust/ip.go
+++ b/client/atrust/ip.go
@@ -80,7 +80,7 @@ func readIPTunnelResponses(reader io.Reader) (net.IP, error) {
 	return net.IPv4(vipData[0], vipData[1], vipData[2], vipData[3]), nil
 }
 
-func (c *Client) getIP() error {
+func (c *Client) getIP(parent context.Context) error {
 	addr := c.BestNodes[c.MajorNodeGroup]
 	if addr == "" {
 		for _, node := range c.BestNodes {
@@ -92,7 +92,10 @@ func (c *Client) getIP() error {
 		return fmt.Errorf("no reachable node for ip request")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, 10*time.Second)
 	defer cancel()
 	conn, err := dialTLSContext(ctx, c.underlayDialer, "tcp", addr, tunnelTLSConfig(c.tlsKeyLogWriter))
 	if err != nil {

--- a/client/atrust/node.go
+++ b/client/atrust/node.go
@@ -21,9 +21,9 @@ type NodeGroup struct {
 
 type nodeGroupsProbeFunc func(map[string][]string) map[string]string
 
-func getBestNodes(nodeGroups map[string]NodeGroup, dialContext client.DialContextFunc, keyLogWriter io.Writer) map[string]string {
+func getBestNodes(ctx context.Context, nodeGroups map[string]NodeGroup, dialContext client.DialContextFunc, keyLogWriter io.Writer) map[string]string {
 	return selectBestNodes(nodeGroups, func(nodeGroups map[string][]string) map[string]string {
-		return getBestReachableNodes(nodeGroups, dialContext, keyLogWriter)
+		return getBestReachableNodes(ctx, nodeGroups, dialContext, keyLogWriter)
 	})
 }
 
@@ -50,7 +50,10 @@ func selectBestNodes(nodeGroups map[string]NodeGroup, probe nodeGroupsProbeFunc)
 	return bestNodes
 }
 
-func getBestReachableNodes(nodeGroups map[string][]string, dialContext client.DialContextFunc, keyLogWriter io.Writer) map[string]string {
+func getBestReachableNodes(ctx context.Context, nodeGroups map[string][]string, dialContext client.DialContextFunc, keyLogWriter io.Writer) map[string]string {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	bestNodes := make(map[string]string)
 	for group, nodes := range nodeGroups {
 		if len(nodes) > 0 {
@@ -79,7 +82,7 @@ func getBestReachableNodes(nodeGroups map[string][]string, dialContext client.Di
 				tcping.SetTarget(&target)
 
 				pingList = append(pingList, tcping)
-				ch := tcping.Start()
+				ch := tcping.StartWithContext(ctx)
 				chList = append(chList, ch)
 			}
 
@@ -130,7 +133,7 @@ func (c *Client) updateBestNodes(ctx context.Context, interval time.Duration) {
 		case <-ticker.C:
 		}
 
-		bestNodes := getBestNodes(c.NodeGroups, c.underlayDialer.DialContext, c.tlsKeyLogWriter)
+		bestNodes := getBestNodes(ctx, c.NodeGroups, c.underlayDialer.DialContext, c.tlsKeyLogWriter)
 		c.BestNodesRWMutex.Lock()
 		c.BestNodes = bestNodes
 		c.BestNodesRWMutex.Unlock()

--- a/client/atrust/setup_context_test.go
+++ b/client/atrust/setup_context_test.go
@@ -1,0 +1,57 @@
+package atrust
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+type blockingUnderlayDialer struct{}
+
+func (blockingUnderlayDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (blockingUnderlayDialer) ExcludeIP(net.IP) {}
+
+func TestSetupContextCancellationReachesManifestDial(t *testing.T) {
+	client := NewClient(ClientOptions{UnderlayDialer: blockingUnderlayDialer{}})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.SetupContext(ctx, SetupOptions{ServerAddress: "vpn.example", ServerPort: 443})
+		done <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SetupContext did not cancel in-flight manifest dial")
+	}
+}
+
+func TestClientCloseCancelsSetupContext(t *testing.T) {
+	client := NewClient(ClientOptions{UnderlayDialer: blockingUnderlayDialer{}})
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.SetupContext(context.Background(), SetupOptions{ServerAddress: "vpn.example", ServerPort: 443})
+		done <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	client.Close()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Client.Close did not cancel in-flight setup")
+	}
+}


### PR DESCRIPTION
This adds additive context-aware aTrust APIs so callers can cancel in-flight authentication/setup work without changing the existing API behavior.

Changes:
- keep `auth.NewSession` and `Client.Setup` as compatibility wrappers
- add caller context support for auth sessions
- add `Client.SetupContext`
- propagate setup context through auth/manifest requests, node probing and IP acquisition
- tie setup cancellation to the existing client lifecycle so `Client.Close()` also interrupts an in-flight setup
- add tests for request cancellation, setup cancellation and close-driven cancellation

The existing TCP probe already supports `StartWithContext`, so this mainly connects the caller context through the current lifecycle rather than adding a second cancellation mechanism.

I also validated the combined TLS + context candidate from the Android consumer side: Go tests/vet, gomobile AAR, Android release unit tests, lint and unsigned APK all pass.