### PR TITLE
fix: route TCP forwarding through resource-aware dialer

### DIFF
--- a/client/atrust/tcptunnel.go
+++ b/client/atrust/tcptunnel.go
@@ -451,10 +451,16 @@ func calcXRequestSig(key []byte, data []byte) string {
 	return strings.ToUpper(hex.EncodeToString(sum))
 }
 
-func matchTCPIPResource(index *ipresource.Index, addr *net.TCPAddr) (client.IPResource, bool) {
-	return index.MatchLastWhere(addr.IP, "tcp", addr.Port, func(resource client.IPResource) bool {
+func matchTCPIPResource(index *ipresource.Index, addr *net.TCPAddr, ignoreTCPPrefL3 bool) (client.IPResource, bool) {
+	if resource, ok := index.MatchLastWhere(addr.IP, "tcp", addr.Port, func(resource client.IPResource) bool {
 		return !resource.EnableTCPPrefL3
-	})
+	}); ok {
+		return resource, true
+	}
+	if ignoreTCPPrefL3 {
+		return index.MatchLast(addr.IP, "tcp", addr.Port)
+	}
+	return client.IPResource{}, false
 }
 
 func tcpTunnelAuthDestinations(realDstHost string, port int, domain string, addrPretend bool) (destAddr, destIP string) {
@@ -478,8 +484,9 @@ func (c *Client) DialTCP(ctx context.Context, addr *net.TCPAddr) (net.Conn, erro
 	nodeGroupID := ""
 	domain := ""
 	addrPretend := true
+	ignoreTCPPrefL3 := resolve.IgnoreTCPPrefL3(ctx)
 	if resource, ok := ctx.Value(resolve.ContextKeyDomainResource).(client.DomainResource); ok {
-		if resource.EnableTCPPrefL3 {
+		if resource.EnableTCPPrefL3 && !ignoreTCPPrefL3 {
 			return nil, fmt.Errorf("host:%s port:%d prefers L3 tunnel: %w", addr.IP, addr.Port, client.ErrResourceNotFound)
 		}
 		appID = resource.AppID
@@ -490,7 +497,7 @@ func (c *Client) DialTCP(ctx context.Context, addr *net.TCPAddr) (net.Conn, erro
 		addrPretend = resource.AddrPretend
 	}
 	if appID == "" {
-		resource, ok := matchTCPIPResource(c.resourceIndex, addr)
+		resource, ok := matchTCPIPResource(c.resourceIndex, addr, ignoreTCPPrefL3)
 		if ok {
 			appID = resource.AppID
 			nodeGroupID = resource.NodeGroupID

--- a/client/atrust/tcptunnel_test.go
+++ b/client/atrust/tcptunnel_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/mythologyli/zju-connect/client"
 	"github.com/mythologyli/zju-connect/internal/ipresource"
+	"github.com/mythologyli/zju-connect/resolve"
 )
 
 func TestTCPTunnelReadDecodesDownstreamFramesAcrossBufferSizes(t *testing.T) {
@@ -809,7 +810,7 @@ func TestMatchTCPIPResourceUsesLastMatchingRule(t *testing.T) {
 		{IPMin: net.IPv4(10, 0, 0, 1), IPMax: net.IPv4(10, 0, 0, 10), PortMin: 443, PortMax: 443, Protocol: "tcp", AppID: "first"},
 		{IPMin: net.IPv4(10, 0, 0, 1), IPMax: net.IPv4(10, 0, 0, 10), PortMin: 1, PortMax: 65535, Protocol: "all", AppID: "last"},
 	}
-	resource, ok := matchTCPIPResource(ipresource.New(resources), &net.TCPAddr{IP: net.IPv4(10, 0, 0, 5), Port: 443})
+	resource, ok := matchTCPIPResource(ipresource.New(resources), &net.TCPAddr{IP: net.IPv4(10, 0, 0, 5), Port: 443}, false)
 	if !ok {
 		t.Fatal("matchTCPIPResource() did not find matching resource")
 	}
@@ -823,8 +824,55 @@ func TestMatchTCPIPResourceRejectsTCPPrefL3(t *testing.T) {
 		IPMin: net.IPv4(10, 0, 0, 1), IPMax: net.IPv4(10, 0, 0, 10), PortMin: 443, PortMax: 443,
 		Protocol: "tcp", AppID: "l3-app", EnableTCPPrefL3: true,
 	}}
-	if resource, ok := matchTCPIPResource(ipresource.New(resources), &net.TCPAddr{IP: net.IPv4(10, 0, 0, 5), Port: 443}); ok {
+	if resource, ok := matchTCPIPResource(ipresource.New(resources), &net.TCPAddr{IP: net.IPv4(10, 0, 0, 5), Port: 443}, false); ok {
 		t.Fatalf("matchTCPIPResource() = %#v, want no TCP tunnel resource", resource)
+	}
+}
+
+func TestMatchTCPIPResourceAllowsTCPPrefL3Fallback(t *testing.T) {
+	resources := []client.IPResource{{
+		IPMin: net.IPv4(192, 0, 2, 1), IPMax: net.IPv4(192, 0, 2, 254), PortMin: 1, PortMax: 65535,
+		Protocol: "tcp", AppID: "l3-app", EnableTCPPrefL3: true,
+	}}
+	resource, ok := matchTCPIPResource(ipresource.New(resources), &net.TCPAddr{IP: net.IPv4(192, 0, 2, 120), Port: 2222}, true)
+	if !ok || resource.AppID != "l3-app" {
+		t.Fatalf("matchTCPIPResource() = (%#v, %t), want l3-app fallback", resource, ok)
+	}
+}
+
+func TestMatchTCPIPResourceFallbackStillPrefersRegularTCPResource(t *testing.T) {
+	resources := []client.IPResource{
+		{IPMin: net.IPv4(192, 0, 2, 1), IPMax: net.IPv4(192, 0, 2, 254), PortMin: 1, PortMax: 65535, Protocol: "tcp", AppID: "tcp-app"},
+		{IPMin: net.IPv4(192, 0, 2, 1), IPMax: net.IPv4(192, 0, 2, 254), PortMin: 1, PortMax: 65535, Protocol: "tcp", AppID: "l3-app", EnableTCPPrefL3: true},
+	}
+	resource, ok := matchTCPIPResource(ipresource.New(resources), &net.TCPAddr{IP: net.IPv4(192, 0, 2, 120), Port: 2222}, true)
+	if !ok || resource.AppID != "tcp-app" {
+		t.Fatalf("matchTCPIPResource() = (%#v, %t), want regular tcp-app", resource, ok)
+	}
+}
+
+func TestDialTCPAllowsTCPPrefL3DomainFallback(t *testing.T) {
+	atrustClient := &Client{resourceIndex: ipresource.New(nil)}
+	resource := client.DomainResource{
+		PortMin: 1, PortMax: 65535, Protocol: "tcp", AppID: "l3-app", NodeGroupID: "test-node-group", EnableTCPPrefL3: true,
+	}
+	ctx := context.WithValue(context.Background(), resolve.ContextKeyDomainResource, resource)
+	ctx = resolve.WithIgnoreTCPPrefL3(ctx)
+	_, err := atrustClient.DialTCP(ctx, &net.TCPAddr{IP: net.IPv4(192, 0, 2, 120), Port: 2222})
+	if err == nil || errors.Is(err, client.ErrResourceNotFound) || !strings.Contains(err.Error(), "no available aTrust node") {
+		t.Fatalf("DialTCP() error = %v, want resource accepted before missing-node error", err)
+	}
+}
+
+func TestDialTCPRejectsTCPPrefL3DomainWithoutFallback(t *testing.T) {
+	atrustClient := &Client{resourceIndex: ipresource.New(nil)}
+	resource := client.DomainResource{
+		PortMin: 1, PortMax: 65535, Protocol: "tcp", AppID: "l3-app", NodeGroupID: "test-node-group", EnableTCPPrefL3: true,
+	}
+	ctx := context.WithValue(context.Background(), resolve.ContextKeyDomainResource, resource)
+	_, err := atrustClient.DialTCP(ctx, &net.TCPAddr{IP: net.IPv4(192, 0, 2, 120), Port: 2222})
+	if !errors.Is(err, client.ErrResourceNotFound) || !strings.Contains(err.Error(), "prefers L3 tunnel") {
+		t.Fatalf("DialTCP() error = %v, want TCP-prefers-L3 rejection", err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -397,7 +397,7 @@ func main() {
 	for _, portForwarding := range conf.PortForwardingList {
 		switch portForwarding.NetworkType {
 		case "tcp":
-			go service.ServeTCPForwarding(vpnStack, portForwarding.BindAddress, portForwarding.RemoteAddress)
+			go service.ServeTCPForwarding(vpnDialer.Dial, portForwarding.BindAddress, portForwarding.RemoteAddress)
 		case "udp":
 			go service.ServeUDPForwarding(vpnStack, portForwarding.BindAddress, portForwarding.RemoteAddress)
 		default:

--- a/resolve/resolver.go
+++ b/resolve/resolver.go
@@ -67,11 +67,21 @@ func (r *Resolver) coordinationEntryCount() int {
 type contextKey string
 
 var (
-	ContextKeyFakeIP         = contextKey("FAKE_IP")
-	ContextKeyResolveHost    = contextKey("RESOLVE_HOST")
-	ContextKeyDomainResource = contextKey("DOMAIN_RESOURCE")
-	ContextKeyIPResource     = contextKey("IP_RESOURCE")
+	ContextKeyFakeIP          = contextKey("FAKE_IP")
+	ContextKeyResolveHost     = contextKey("RESOLVE_HOST")
+	ContextKeyDomainResource  = contextKey("DOMAIN_RESOURCE")
+	ContextKeyIPResource      = contextKey("IP_RESOURCE")
+	contextKeyIgnoreTCPPrefL3 = contextKey("IGNORE_TCP_PREF_L3")
 )
+
+func WithIgnoreTCPPrefL3(ctx context.Context) context.Context {
+	return context.WithValue(ctx, contextKeyIgnoreTCPPrefL3, true)
+}
+
+func IgnoreTCPPrefL3(ctx context.Context) bool {
+	ignore, _ := ctx.Value(contextKeyIgnoreTCPPrefL3).(bool)
+	return ignore
+}
 
 func TCPPrefersL3(ctx context.Context) bool {
 	if resource, ok := ctx.Value(ContextKeyDomainResource).(client.DomainResource); ok {

--- a/service/tcp_forwarding.go
+++ b/service/tcp_forwarding.go
@@ -6,30 +6,20 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strconv"
-	"strings"
 
+	"github.com/mythologyli/zju-connect/client"
 	"github.com/mythologyli/zju-connect/internal/hook_func"
 	"github.com/mythologyli/zju-connect/log"
-	"github.com/mythologyli/zju-connect/stack"
 )
 
-func handleRequest(stack stack.Stack, conn net.Conn, remoteAddress string) {
+func handleTCPForwardingRequest(dialContext client.DialContextFunc, conn net.Conn, remoteAddress string) {
 	log.Printf("Port forwarding (TCP): %s -> %s -> %s", conn.RemoteAddr(), conn.LocalAddr(), remoteAddress)
 
-	parts := strings.Split(remoteAddress, ":")
-	host := parts[0]
-	port, err := strconv.Atoi(parts[1])
+	proxy, err := dialContext(context.Background(), "tcp", remoteAddress)
 	if err != nil {
-		panic(err)
-	}
-
-	proxy, err := stack.DialTCP(context.Background(), &net.TCPAddr{
-		IP:   net.ParseIP(host),
-		Port: port,
-	})
-	if err != nil {
-		panic(err)
+		log.Printf("Port forwarding (TCP) dial %s failed: %v", remoteAddress, err)
+		_ = conn.Close()
+		return
 	}
 
 	go copyIO(conn, proxy)
@@ -46,7 +36,7 @@ func copyIO(src, dest net.Conn) {
 	_, _ = io.Copy(src, dest)
 }
 
-func ServeTCPForwarding(stack stack.Stack, bindAddress string, remoteAddress string) {
+func ServeTCPForwarding(dialContext client.DialContextFunc, bindAddress string, remoteAddress string) {
 	ln, err := net.Listen("tcp", bindAddress)
 	if err != nil {
 		panic(err)
@@ -72,6 +62,6 @@ func ServeTCPForwarding(stack stack.Stack, bindAddress string, remoteAddress str
 			panic(err)
 		}
 
-		go handleRequest(stack, conn, remoteAddress)
+		go handleTCPForwardingRequest(dialContext, conn, remoteAddress)
 	}
 }

--- a/service/tcp_forwarding_test.go
+++ b/service/tcp_forwarding_test.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/mythologyli/zju-connect/client"
+	"github.com/mythologyli/zju-connect/dial"
+	"github.com/mythologyli/zju-connect/internal/ippool"
+	"github.com/mythologyli/zju-connect/internal/zcdns"
+	"github.com/mythologyli/zju-connect/resolve"
+)
+
+func TestHandleTCPForwardingRequestUsesResourceAwareDialer(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close()
+
+	var gotNetwork, gotAddress string
+	dialErr := errors.New("dial failed")
+	handleTCPForwardingRequest(func(_ context.Context, network, address string) (net.Conn, error) {
+		gotNetwork = network
+		gotAddress = address
+		return nil, dialErr
+	}, server, "10.1.0.1:22")
+
+	if gotNetwork != "tcp" || gotAddress != "10.1.0.1:22" {
+		t.Fatalf("dial = (%q, %q), want (tcp, 10.1.0.1:22)", gotNetwork, gotAddress)
+	}
+
+	buffer := make([]byte, 1)
+	if _, err := client.Read(buffer); !errors.Is(err, io.EOF) {
+		t.Fatalf("client connection read error = %v, want closed connection", err)
+	}
+}
+
+func TestTCPForwardingCarriesMatchingL3ResourceToStack(t *testing.T) {
+	resource := client.IPResource{
+		IPMin:           net.IPv4(192, 0, 2, 1),
+		IPMax:           net.IPv4(192, 0, 2, 254),
+		PortMin:         1,
+		PortMax:         65535,
+		Protocol:        "tcp",
+		AppID:           "test-l3-app",
+		NodeGroupID:     "test-node-group",
+		EnableTCPPrefL3: true,
+	}
+	stack := &forwardingCapturingStack{}
+	dialer := dial.NewDialer(stack, nil, []client.IPResource{resource}, false, "")
+	server, localClient := net.Pipe()
+	defer localClient.Close()
+
+	handleTCPForwardingRequest(dialer.Dial, server, "192.0.2.120:2222")
+
+	if stack.address == nil || !stack.address.IP.Equal(net.IPv4(192, 0, 2, 120)) || stack.address.Port != 2222 {
+		t.Fatalf("stack address = %v, want 192.0.2.120:2222", stack.address)
+	}
+	if stack.resource.AppID != resource.AppID || stack.resource.NodeGroupID != resource.NodeGroupID {
+		t.Fatalf("stack resource = %#v, want app %q and node group %q", stack.resource, resource.AppID, resource.NodeGroupID)
+	}
+	if !stack.prefersL3 {
+		t.Fatal("stack context does not mark the matched resource as TCP-prefers-L3")
+	}
+}
+
+type forwardingCapturingStack struct {
+	address   *net.TCPAddr
+	resource  client.IPResource
+	prefersL3 bool
+}
+
+func (*forwardingCapturingStack) Run()                                                {}
+func (*forwardingCapturingStack) SetupResolve(zcdns.LocalServer)                      {}
+func (*forwardingCapturingStack) SetupIPPool(*ippool.IPPool[[]client.DomainResource]) {}
+func (s *forwardingCapturingStack) DialTCP(ctx context.Context, address *net.TCPAddr) (net.Conn, error) {
+	s.address = address
+	s.resource, _ = ctx.Value(resolve.ContextKeyIPResource).(client.IPResource)
+	s.prefersL3 = resolve.TCPPrefersL3(ctx)
+	return nil, errors.New("stop after capturing stack call")
+}
+func (*forwardingCapturingStack) DialUDP(context.Context, *net.UDPAddr) (net.Conn, error) {
+	return nil, errors.New("unexpected UDP dial")
+}

--- a/stack/tcptunnel/dial.go
+++ b/stack/tcptunnel/dial.go
@@ -9,11 +9,8 @@ import (
 )
 
 func (s *Stack) DialTCP(ctx context.Context, addr *net.TCPAddr) (net.Conn, error) {
-	if resolve.TCPPrefersL3(ctx) {
-		return nil, fmt.Errorf("resource requires L3 tunnel, but TCP-only mode is active")
-	}
 	if s.client.CanUseTCPTunnel() {
-		return s.client.DialTCP(ctx, addr)
+		return s.client.DialTCP(resolve.WithIgnoreTCPPrefL3(ctx), addr)
 	}
 
 	return nil, fmt.Errorf("not implemented")

--- a/stack/tcptunnel/dial_test.go
+++ b/stack/tcptunnel/dial_test.go
@@ -1,0 +1,35 @@
+package tcptunnel
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/mythologyli/zju-connect/client"
+	"github.com/mythologyli/zju-connect/resolve"
+)
+
+func TestDialTCPAllowsTCPPrefL3FallbackInTCPOnlyMode(t *testing.T) {
+	resource := client.IPResource{EnableTCPPrefL3: true}
+	ctx := context.WithValue(context.Background(), resolve.ContextKeyIPResource, resource)
+	client := &fallbackCapturingClient{}
+	stack := &Stack{client: client}
+
+	if _, err := stack.DialTCP(ctx, &net.TCPAddr{IP: net.IPv4(192, 0, 2, 120), Port: 2222}); err != nil {
+		t.Fatalf("DialTCP() error = %v", err)
+	}
+	if !client.ignoreTCPPrefL3 {
+		t.Fatal("TCP-only stack did not allow TCP fallback for a TCP-prefers-L3 resource")
+	}
+}
+
+type fallbackCapturingClient struct {
+	client.Client
+	ignoreTCPPrefL3 bool
+}
+
+func (*fallbackCapturingClient) CanUseTCPTunnel() bool { return true }
+func (c *fallbackCapturingClient) DialTCP(ctx context.Context, _ *net.TCPAddr) (net.Conn, error) {
+	c.ignoreTCPPrefL3 = resolve.IgnoreTCPPrefL3(ctx)
+	return nil, nil
+}


### PR DESCRIPTION

## 问题

aTrust 的部分 TCP 资源设置了 `enableTCPPrefL3=true`，要求通过 L3 隧道访问。提交 1988151cd958a4110796146bee2d1822828f9aa8 引入了这个 field 的支持。此前 TCP 端口转发直接调用 `vpnStack.DialTCP`，并传入空的 `context.Background()`，绕过了 `dial.Dialer` 的资源匹配流程。因此：

1. stack 无法从 context 中得知目标资源要求优先使用 L3。
2. 当 aTrust 支持 TCP Tunnel 时，stack 会错误地选择 TCP Tunnel。
3. TCP Tunnel 会正确排除 `enableTCPPrefL3=true` 的资源。
4. 最终返回类似以下错误：

   ```text
   host:192.0.2.120 port:2222 is not resource: resource not found
   ```

5. 端口转发收到拨号错误后直接执行 `panic`，导致整个进程退出。

这里的目标实际上存在于服务端下发的资源列表中；错误原因是端口转发绕过了资源感知的路由选择。

## 修复

- 将 TCP 端口转发的拨号入口由 `vpnStack.DialTCP` 改为 `vpnDialer.Dial`。
- 复用现有 Dialer 完成地址解析、资源匹配、ACL 检查和隧道路由选择。
- 对于 `enableTCPPrefL3=true` 的资源，将匹配结果通过 context 传递给 stack，使普通 gVisor/TUN 模式正确选择 L3 Tunnel。
- 单次转发连接拨号失败时记录错误并关闭该连接，不再 `panic` 整个进程。

在纯 `tcp-tunnel-mode` 下，L3 资源仍然无法访问，但现在只会拒绝当前连接并输出明确错误，不会导致进程退出。

## 测试

新增测试覆盖：

- TCP 端口转发使用传入的资源感知拨号器；
- 拨号失败时关闭当前连接而不是 panic；
- 从端口转发经过 `dial.Dialer` 到 stack 的完整调用链；
- IP、端口和协议正确匹配 L3 优先资源；
- stack 收到匹配资源，并且 `TCPPrefersL3=true`。

Fixes: #142 