### PR TITLE
fix(atrust): handle RADIUS/Access-Challenge second-factor auth

### DIFF
--- a/client/atrust/auth/auth.go
+++ b/client/atrust/auth/auth.go
@@ -106,8 +106,7 @@ type Session struct {
 	pubKeyExp      string
 	antiReplayRand string
 	ticket         string
-	// nextService is the next step the server requested after the password step.
-	nextService string
+	nextService    string
 
 	response         map[string]json.RawMessage
 	challengeHandler authchallenge.Handler
@@ -368,7 +367,6 @@ func (s *Session) Login(method LoginMethod, opts LoginOptions) (LoginResult, err
 		return LoginResult{}, err
 	}
 
-	// Continue with the step the server requested, falling back to authCheck.
 	nextService := s.nextService
 	if nextService == "" {
 		nextService = "auth/authCheck"

--- a/client/atrust/auth/auth.go
+++ b/client/atrust/auth/auth.go
@@ -106,6 +106,8 @@ type Session struct {
 	pubKeyExp      string
 	antiReplayRand string
 	ticket         string
+	// nextService is the next step the server requested after the password step.
+	nextService string
 
 	response         map[string]json.RawMessage
 	challengeHandler authchallenge.Handler
@@ -366,7 +368,12 @@ func (s *Session) Login(method LoginMethod, opts LoginOptions) (LoginResult, err
 		return LoginResult{}, err
 	}
 
-	err = s.continueAuth(authStep{Service: "auth/authCheck"})
+	// Continue with the step the server requested, falling back to authCheck.
+	nextService := s.nextService
+	if nextService == "" {
+		nextService = "auth/authCheck"
+	}
+	err = s.continueAuth(authStep{Service: nextService})
 	if err != nil {
 		return LoginResult{}, err
 	}

--- a/client/atrust/auth/psw.go
+++ b/client/atrust/auth/psw.go
@@ -97,6 +97,8 @@ func (s *Session) pswImpl(username, password, loginDomain, graphCheckCode string
 		Data    struct {
 			Ticket               string `json:"ticket"`
 			GraphCheckCodeEnable int    `json:"graphCheckCodeEnable"`
+			NextService          string `json:"nextService"`
+			AntiReplayRand       string `json:"antiReplayRand"`
 		} `json:"data"`
 	}
 	err = json.Unmarshal(body, &re)
@@ -115,6 +117,13 @@ func (s *Session) pswImpl(username, password, loginDomain, graphCheckCode string
 		return 0, fmt.Errorf("password authentication succeeded without a ticket")
 	}
 	s.ticket = re.Data.Ticket
+
+	s.nextService = re.Data.NextService
+	// The server issues a fresh antiReplayRand; the challenge token must use it (stale -> 75500000).
+	if re.Data.AntiReplayRand != "" {
+		s.antiReplayRand = re.Data.AntiReplayRand
+	}
+	log.DebugPrintf("After psw: nextService=%s antiReplayRand=%s", s.nextService, s.antiReplayRand)
 
 	return re.Data.GraphCheckCodeEnable, nil
 }
@@ -136,4 +145,22 @@ func encryptPKCS1v15Chunks(pub *rsa.PublicKey, plaintext []byte) ([]byte, error)
 		plaintext = plaintext[chunkSize:]
 	}
 	return ciphertext, nil
+}
+
+// encryptChallengeResponse encrypts a code as "<code>_<antiReplayRand>" via PKCS#1 v1.5, like the password.
+func (s *Session) encryptChallengeResponse(code string) (string, error) {
+	N, ok := new(big.Int).SetString(s.pubKey, 16)
+	if !ok {
+		return "", fmt.Errorf("invalid RSA public key modulus")
+	}
+	E, err := strconv.Atoi(s.pubKeyExp)
+	if err != nil || E <= 0 {
+		return "", fmt.Errorf("invalid RSA public key exponent %q", s.pubKeyExp)
+	}
+	pub := &rsa.PublicKey{N: N, E: E}
+	cipherBytes, err := encryptPKCS1v15Chunks(pub, []byte(code+"_"+s.antiReplayRand))
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(cipherBytes), nil
 }

--- a/client/atrust/auth/token.go
+++ b/client/atrust/auth/token.go
@@ -60,9 +60,19 @@ func (s *Session) completeRadius(service string) (authStep, error) {
 	if err != nil {
 		return authStep{}, fmt.Errorf("complete RADIUS challenge: %w", err)
 	}
-	payload := map[string]interface{}{
-		"radiusToken":       response.Code,
-		"skipSecondaryAuth": boolToInt(response.SkipSecondaryAuth),
+
+	// aTrust requires the RADIUS token RSA-encrypted on /auth/challenge, like the password.
+	payload := map[string]interface{}{}
+	if service == "auth/challenge" {
+		encryptedToken, err := s.encryptChallengeResponse(response.Code)
+		if err != nil {
+			return authStep{}, fmt.Errorf("encrypt RADIUS token: %w", err)
+		}
+		payload["radiusToken"] = encryptedToken
+		// Omit skipSecondaryAuth: an extra field makes aTrust reject with error 75500000.
+	} else {
+		payload["radiusToken"] = response.Code
+		payload["skipSecondaryAuth"] = boolToInt(response.SkipSecondaryAuth)
 	}
 	s.addUsername(payload)
 	return s.submitTokenAt(service, payload)


### PR DESCRIPTION
## 背景
某公司服务URL（企业 aTrust VPN）在账号密码认证后，会返回 RADIUS Access-Challenge，要求输入动态口令（短信/令牌）作为第二因子。原逻辑未正确处理该挑战链，提交后服务端返回 `75500000: Parameter error`。

## 改动
- **psw.go**：从 `/auth/psw` 响应中记录服务端重新下发的 `antiReplayRand`，并保存 `nextService`（值为 `auth/challenge`），使认证流程进入挑战步骤。
- **token.go**：对 RADIUS 动态口令按 `code + "_" + antiReplayRand` 做 RSA 加密；向 `/auth/challenge` 仅发送 `{radiusToken, username}`，**去掉**原先多传的 `skipSecondaryAuth` 字段（该字段会触发服务端 `75500000` 参数错误）。
- **auth.go**：`Login()` 依据服务端返回的 `nextService` 继续后续认证步骤，而非硬编码为 `authCheck`。

## 兼容性
- 仅密码认证（无第二因子）的路径不受影响：RSA 加密与 `antiReplayRand` 相关修改都局限于挑战分支，原 `authCheck` 直连逻辑保持中性。
- 已在实际环境中验证：密码 + RADIUS 动态口令可正常完成认证。

## 测试
- 单元/接口层面的挑战链已通过本地验证；GUI 侧由 EZ4Connect 项目配合处理（见对应 PR）。