### PR TITLE
feat: support sid refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@
 
 + `update-best-nodes-interval`: 自动选择最优线路的更新间隔，单位为秒，默认为 `300` 秒。设置为 `0` 则禁用自动选择最优线路
 
++ `session-refresh-interval`: aTrust SID 刷新间隔，单位为秒，默认为 `1800`。设置为 `0` 则禁用定时刷新。
+
 + `auth-info`: 仅获取 aTrust 验证信息而不登录，一般不需要加此参数。可用于查看服务端支持的验证方式
 
 + `trust-device`: 设置当前设备为授信终端（需要已登录的 `-client-data-file`），不启用隧道

--- a/README_en.md
+++ b/README_en.md
@@ -203,6 +203,7 @@ The old `disable_zju_dns` and `zju_dns_server` names, including their command-li
 + `cas-ticket`: CAS verification ticket, defaults to empty, which triggers interactive verification.
 + `phone`: Phone number used for SMS verification code login.
 + `update-best-nodes-interval`: Interval for updating the optimal line automatically, in seconds, default is `300`. Set to `0` to disable automatic optimal line selection.
++ `session-refresh-interval`: aTrust SID refresh interval in seconds, default `1800`. Set to `0` to disable periodic refresh. The TOML key is `session_refresh_interval`; the environment variable is `ZJU_CONNECT_SESSION_REFRESH_INTERVAL`.
 + `auth-info`: Only get aTrust authentication information without logging in, generally no need to add this argument. Can be used to check supported authentication methods.
 + `trust-device`: Trust the current device (requires logged-in `-client-data-file`), does not start the tunnel.
 + `untrust-device`: Untrust the current device (requires logged-in `-client-data-file`), does not start the tunnel.

--- a/client/atrust/auth/refresh.go
+++ b/client/atrust/auth/refresh.go
@@ -1,0 +1,44 @@
+package auth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+)
+
+var ErrSessionInvalid = errors.New("aTrust session is invalid; reauthentication required")
+
+// Restore initializes the control-plane session when tunnel credentials were
+// supplied directly. A supplied SID takes precedence over persisted cookies.
+func (s *Session) Restore(deviceID, sid string, cookies []Cookie) {
+	s.deviceID = deviceID
+	env, _ := json.Marshal(map[string]string{"deviceId": deviceID})
+	s.env = base64.StdEncoding.EncodeToString(env)
+	for _, cookie := range cookies {
+		s.client.Jar.SetCookies(&url.URL{Host: cookie.Host, Scheme: cookie.Scheme}, []*http.Cookie{{Name: cookie.Name, Value: cookie.Value, Path: "/"}})
+	}
+	if sid != "" {
+		s.client.Jar.SetCookies(&url.URL{Host: s.baseHost, Scheme: "https"}, []*http.Cookie{{Name: "sid", Value: sid, Path: "/"}})
+	}
+}
+
+// Snapshot must be taken after the last HTTP response, which may replace sid.
+func (s *Session) Snapshot() (LoginResult, error) {
+	sid, cookies := sessionCookies(s)
+	if sid == "" {
+		return LoginResult{}, ErrSessionInvalid
+	}
+	return LoginResult{SID: sid, Cookies: cookies}, nil
+}
+
+// Refresh maintains an existing session; it never starts an interactive login.
+// Calls on the same Session must be serialized with login and other requests.
+func (s *Session) Refresh(ctx context.Context) (LoginResult, error) {
+	if _, _, err := s.authConfigContext(ctx, false, false, true); err != nil {
+		return LoginResult{}, err
+	}
+	return s.Snapshot()
+}

--- a/client/atrust/auth/refresh_test.go
+++ b/client/atrust/auth/refresh_test.go
@@ -1,0 +1,134 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRefreshUsesLatestCookiesAndCSRF(t *testing.T) {
+	calls := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Method != "GET" || r.URL.Path != "/passport/v1/public/authConfig" || r.URL.Query().Get("needTicket") != "0" || r.URL.Query().Has("mod") {
+			t.Errorf("unexpected refresh request: %s %s", r.Method, r.URL)
+		}
+		cookie, err := r.Cookie("sid")
+		if err != nil || cookie.Value != fmt.Sprintf("sid-%d", calls-1) {
+			t.Errorf("cookie = %v, %v", cookie, err)
+		}
+		if got := r.Header.Get("x-csrf-token"); got != fmt.Sprintf("csrf-%d", calls-1) {
+			t.Errorf("csrf = %q", got)
+		}
+		http.SetCookie(w, &http.Cookie{Name: "sid", Value: fmt.Sprintf("sid-%d", calls), Path: "/"})
+		fmt.Fprintf(w, `{"code":0,"data":{"isLogin":1,"security":{"csrfToken":"csrf-%d"}}}`, calls)
+	}))
+	defer server.Close()
+	s := NewSession(strings.TrimPrefix(server.URL, "https://"), nil)
+	s.Restore("device", "sid-0", nil)
+	s.csrfToken = "csrf-0"
+	for i := 1; i <= 2; i++ {
+		result, err := s.Refresh(context.Background())
+		if err != nil || result.SID != fmt.Sprintf("sid-%d", i) {
+			t.Fatalf("refresh %d = %+v, %v", i, result, err)
+		}
+		if len(result.Cookies) != 1 || result.Cookies[0].Value != result.SID {
+			t.Fatalf("persisted cookies = %+v", result.Cookies)
+		}
+	}
+}
+
+func TestRefreshRejectsInvalidResponses(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		status    int
+		body      string
+		deleteSID bool
+		invalid   bool
+	}{
+		{"logged out", 200, `{"code":0,"data":{"isLogin":0}}`, false, true},
+		{"invalid SID", 200, `{"code":10000004}`, false, true},
+		{"expired session", 200, `{"code":75500002}`, false, true},
+		{"unauthorized", 401, `{}`, false, true},
+		{"forbidden", 403, `{}`, false, true},
+		{"server error", 503, `{"code":0,"data":{"isLogin":1}}`, false, false},
+		{"business error", 200, `{"code":123,"data":{"isLogin":1}}`, false, false},
+		{"missing code", 200, `{"data":{"isLogin":1}}`, false, false},
+		{"missing login state", 200, `{"code":0,"data":{}}`, false, false},
+		{"bad JSON", 200, `{`, false, false},
+		{"deleted cookie", 200, `{"code":0,"data":{"isLogin":1}}`, true, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.deleteSID {
+					http.SetCookie(w, &http.Cookie{Name: "sid", Path: "/", MaxAge: -1})
+				}
+				w.WriteHeader(tt.status)
+				fmt.Fprint(w, tt.body)
+			}))
+			defer server.Close()
+			s := NewSession(strings.TrimPrefix(server.URL, "https://"), nil)
+			s.Restore("device", "old", nil)
+			result, err := s.Refresh(context.Background())
+			if err == nil || result.SID != "" || errors.Is(err, ErrSessionInvalid) != tt.invalid {
+				t.Fatalf("refresh = %+v, %v", result, err)
+			}
+		})
+	}
+}
+
+func TestSnapshotAfterResourceResponseAndRestorePrecedence(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie, err := r.Cookie("sid")
+		if err != nil || cookie.Value != "explicit" {
+			t.Errorf("cookie = %v, %v", cookie, err)
+		}
+		http.SetCookie(w, &http.Cookie{Name: "sid", Value: "resource-sid", Path: "/"})
+		fmt.Fprint(w, `{"code":0,"data":{}}`)
+	}))
+	defer server.Close()
+	host := strings.TrimPrefix(server.URL, "https://")
+	s := NewSession(host, nil)
+	s.Restore("device", "explicit", []Cookie{{Host: host, Scheme: "https", Name: "sid", Value: "stale"}})
+	if _, err := s.ClientResource(); err != nil {
+		t.Fatal(err)
+	}
+	result, err := s.Snapshot()
+	if err != nil || result.SID != "resource-sid" {
+		t.Fatalf("snapshot = %+v, %v", result, err)
+	}
+}
+
+func TestRefreshCancellation(t *testing.T) {
+	started := make(chan struct{})
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+	s := NewSession(strings.TrimPrefix(server.URL, "https://"), nil)
+	s.Restore("device", "sid", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { _, err := s.Refresh(ctx); done <- err }()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("request did not arrive")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("refresh did not cancel")
+	}
+}

--- a/client/atrust/auth/request.go
+++ b/client/atrust/auth/request.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
@@ -45,6 +46,10 @@ func (s *Session) ServerVersionInfo() ([]byte, error) {
 }
 
 func (s *Session) authConfig(mod, needTicket bool) (int, []AuthInfo, error) {
+	return s.authConfigContext(context.Background(), mod, needTicket, false)
+}
+
+func (s *Session) authConfigContext(ctx context.Context, mod, needTicket, refresh bool) (int, []AuthInfo, error) {
 	log.Println("Perform GET /passport/v1/public/authConfig")
 
 	params := WithSharedParams(nil)
@@ -53,10 +58,15 @@ func (s *Session) authConfig(mod, needTicket bool) (int, []AuthInfo, error) {
 	}
 	if needTicket {
 		params.Set("needTicket", "1")
+	} else if refresh {
+		params.Set("needTicket", "0")
 	}
 
 	u := s.baseURL + "/passport/v1/public/authConfig"
-	req, _ := http.NewRequest("GET", u+"?"+params.Encode(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u+"?"+params.Encode(), nil)
+	if err != nil {
+		return 0, nil, err
+	}
 	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Set("x-csrf-token", s.csrfToken)
 	req.Header.Set("x-sdp-rid", s.rid)
@@ -70,13 +80,23 @@ func (s *Session) authConfig(mod, needTicket bool) (int, []AuthInfo, error) {
 	defer func(Body io.ReadCloser) {
 		_ = Body.Close()
 	}(resp.Body)
-	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return 0, nil, fmt.Errorf("%w: authConfig HTTP %d", ErrSessionInvalid, resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, nil, fmt.Errorf("authConfig HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, err
+	}
 	log.DebugPrintf("Received auth config: %s", string(body))
 
 	var re struct {
+		Code *int `json:"code"`
 		Data struct {
 			AuthServerInfoList []AuthInfo `json:"authServerInfoList"`
-			IsLogin            int        `json:"isLogin"`
+			IsLogin            *int       `json:"isLogin"`
 			CSRF               string     `json:"csrfToken"`
 			Security           struct {
 				CSRF string `json:"csrfToken"`
@@ -91,17 +111,31 @@ func (s *Session) authConfig(mod, needTicket bool) (int, []AuthInfo, error) {
 	if err != nil {
 		return 0, nil, err
 	}
-	log.DebugPrintf("Parsed auth config: %+v", re)
+	if re.Code != nil && *re.Code != 0 {
+		if *re.Code == 10000004 || *re.Code == 75500002 {
+			return 0, nil, fmt.Errorf("%w: authConfig code %d", ErrSessionInvalid, *re.Code)
+		}
+		return 0, nil, fmt.Errorf("authConfig failed with code %d", *re.Code)
+	}
+	if refresh && (re.Code == nil || re.Data.IsLogin == nil) {
+		return 0, nil, fmt.Errorf("authConfig response missing code or isLogin")
+	}
+	if refresh && *re.Data.IsLogin != 1 {
+		return 0, nil, ErrSessionInvalid
+	}
 	responseCSRFToken := re.Data.CSRF
 	if responseCSRFToken == "" {
 		responseCSRFToken = re.Data.Security.CSRF
 	}
 	if len(re.Data.AntiMITM.raw) != 0 {
-		if err := s.checkAntiMITMAuthConfig(resp, re.Data.AntiMITM, responseCSRFToken); err != nil {
+		if err := s.checkAntiMITMAuthConfig(ctx, resp, re.Data.AntiMITM, responseCSRFToken); err != nil {
 			// Official desktop and Android clients report this through their
 			// event/UI layer, but their authentication callers continue.
 			log.Printf("aTrust anti-MITM check failed: %v", err)
 		}
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, nil, err
 	}
 
 	s.csrfToken = responseCSRFToken
@@ -109,10 +143,14 @@ func (s *Session) authConfig(mod, needTicket bool) (int, []AuthInfo, error) {
 	s.pubKeyExp = re.Data.PubKeyExp
 	s.antiReplayRand = re.Data.AntiReplayRand
 
-	return re.Data.IsLogin, re.Data.AuthServerInfoList, nil
+	isLogin := 0
+	if re.Data.IsLogin != nil {
+		isLogin = *re.Data.IsLogin
+	}
+	return isLogin, re.Data.AuthServerInfoList, nil
 }
 
-func (s *Session) checkAntiMITMAuthConfig(resp *http.Response, data antiMITMAttackData, csrfToken string) error {
+func (s *Session) checkAntiMITMAuthConfig(ctx context.Context, resp *http.Response, data antiMITMAttackData, csrfToken string) error {
 	if err := verifySangforChallenge(data); err != nil {
 		return err
 	}
@@ -131,10 +169,14 @@ func (s *Session) checkAntiMITMAuthConfig(resp *http.Response, data antiMITMAtta
 	if data.AntiMITMRequest {
 		return nil
 	}
-	return s.performAntiMITMRequest(data, csrfToken)
+	return s.performAntiMITMRequestContext(ctx, data, csrfToken)
 }
 
 func (s *Session) performAntiMITMRequest(data antiMITMAttackData, csrfToken string) error {
+	return s.performAntiMITMRequestContext(context.Background(), data, csrfToken)
+}
+
+func (s *Session) performAntiMITMRequestContext(ctx context.Context, data antiMITMAttackData, csrfToken string) error {
 	nonce, err := sangforNonce()
 	if err != nil {
 		return fmt.Errorf("aTrust anti-MITM request failed: generate nonce: %w", err)
@@ -146,7 +188,7 @@ func (s *Session) performAntiMITMRequest(data antiMITMAttackData, csrfToken stri
 		params.Set("mobileId", s.deviceID)
 	}
 	u := s.baseURL + "/controller/v1/public/antiMITMRequest"
-	req, err := http.NewRequest(http.MethodPost, u+"?"+params.Encode(), bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u+"?"+params.Encode(), bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}

--- a/client/atrust/client.go
+++ b/client/atrust/client.go
@@ -46,6 +46,8 @@ type SetupOptions struct {
 	ResourceData             []byte
 	BestNodesRefreshInterval time.Duration
 	ChallengeHandler         authchallenge.Handler
+	SessionRefreshInterval   time.Duration
+	SaveClientData           func([]byte) error
 }
 
 type Client struct {
@@ -54,6 +56,10 @@ type Client struct {
 	DeviceID     string
 	ConnectionID string
 	SignKey      string
+
+	sessionMu   sync.RWMutex
+	sessionErr  error
+	refreshDone chan struct{}
 
 	serverAddress   string
 	ipResources     []client.IPResource
@@ -107,6 +113,9 @@ func (c *Client) canResume(resourceData []byte) bool {
 func (c *Client) Close() {
 	c.closeOnce.Do(func() {
 		c.lifecycleCancel()
+		if c.refreshDone != nil {
+			<-c.refreshDone
+		}
 		c.l3TunnelMu.Lock()
 		tunnel := c.l3Tunnel
 		c.l3TunnelMu.Unlock()
@@ -359,6 +368,7 @@ func (c *Client) Setup(options SetupOptions) ([]byte, error) {
 		if c.SignKey == "" {
 			c.SignKey = randHex(64)
 		}
+		sess.Restore(c.DeviceID, c.SID, clientAuthData.Cookies)
 	} else {
 		if clientAuthData.DeviceID == "" {
 			clientAuthData.DeviceID = strings.ToLower(randHex(32))
@@ -382,8 +392,6 @@ func (c *Client) Setup(options SetupOptions) ([]byte, error) {
 			return nil, err
 		}
 		c.Username = loginResult.Username
-		c.SID = loginResult.SID
-		clientAuthData.Cookies = loginResult.Cookies
 
 		resourceData, err = sess.ClientResource()
 		if err != nil {
@@ -392,6 +400,13 @@ func (c *Client) Setup(options SetupOptions) ([]byte, error) {
 		}
 
 	}
+	snapshot, err := sess.Snapshot()
+	if err != nil {
+		return nil, err
+	}
+	c.setSessionSID(snapshot.SID, nil)
+	clientAuthData.DeviceID = c.DeviceID
+	clientAuthData.Cookies = snapshot.Cookies
 	authData, err := json.Marshal(clientAuthData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal client data: %w", err)
@@ -419,6 +434,14 @@ func (c *Client) Setup(options SetupOptions) ([]byte, error) {
 	c.l3TunnelMu.Lock()
 	c.l3Tunnel = l3Tunnel
 	c.l3TunnelMu.Unlock()
+	if options.SaveClientData != nil {
+		if err := options.SaveClientData(authData); err != nil {
+			return nil, fmt.Errorf("failed to save client data: %w", err)
+		}
+	}
+	if options.SessionRefreshInterval > 0 {
+		c.startSessionRefresh(sess.Refresh, clientAuthData, options.SaveClientData, options.SessionRefreshInterval)
+	}
 
 	if options.BestNodesRefreshInterval > 0 {
 		go c.updateBestNodes(c.lifecycleCtx, options.BestNodesRefreshInterval)

--- a/client/atrust/ip.go
+++ b/client/atrust/ip.go
@@ -102,7 +102,11 @@ func (c *Client) getIP() error {
 		_ = conn.Close()
 	}(conn)
 
-	authPayload, err := json.Marshal(authRequestSID{Sid: c.SID})
+	sid, err := c.sessionSID()
+	if err != nil {
+		return err
+	}
+	authPayload, err := json.Marshal(authRequestSID{Sid: sid})
 	if err != nil {
 		return fmt.Errorf("failed to marshal IP tunnel auth request: %w", err)
 	}

--- a/client/atrust/l3tunnel.go
+++ b/client/atrust/l3tunnel.go
@@ -57,7 +57,7 @@ func NewL3Tunnel(aTrustClient *Client) (*L3Tunnel, error) {
 	}
 	t.connect = func(ctx context.Context, addr string, conntrackMgr *conntrackMgr) (*l3TunnelConn, error) {
 		info := clientInfo{
-			sid:          aTrustClient.SID,
+			sidProvider:  aTrustClient.sessionSID,
 			deviceID:     aTrustClient.DeviceID,
 			connectionID: aTrustClient.ConnectionID,
 			username:     aTrustClient.Username,

--- a/client/atrust/l3tunnelconn.go
+++ b/client/atrust/l3tunnelconn.go
@@ -60,9 +60,17 @@ var dataFramePool = sync.Pool{
 
 type clientInfo struct {
 	sid          string
+	sidProvider  func() (string, error)
 	deviceID     string
 	connectionID string
 	username     string
+}
+
+func (info clientInfo) currentSID() (string, error) {
+	if info.sidProvider != nil {
+		return info.sidProvider()
+	}
+	return info.sid, nil
 }
 
 type l3TunnelConn struct {
@@ -628,11 +636,15 @@ func (c *l3TunnelConn) writeRaw(label string, data []byte) error {
 }
 
 func buildAuthRequest(info clientInfo, signKey []byte, meta packetMeta, ct *conntrack) ([]byte, error) {
+	sid, err := info.currentSID()
+	if err != nil {
+		return nil, err
+	}
 	url := fmt.Sprintf("%s:%s:%d", protoName(meta.proto), meta.dstIP.String(), meta.dstPort)
 	env := defaultEnv(info)
 
 	req := authRequestIP{
-		Sid:           info.sid,
+		Sid:           sid,
 		AppID:         ct.appID,
 		URL:           url,
 		DeviceID:      info.deviceID,
@@ -872,7 +884,11 @@ func logFrame(prefix string, data []byte) {
 }
 
 func (c *l3TunnelConn) authTunnel() error {
-	req, err := json.Marshal(authRequestSID{Sid: c.info.sid})
+	sid, err := c.info.currentSID()
+	if err != nil {
+		return err
+	}
+	req, err := json.Marshal(authRequestSID{Sid: sid})
 	if err != nil {
 		return err
 	}

--- a/client/atrust/session.go
+++ b/client/atrust/session.go
@@ -1,0 +1,67 @@
+package atrust
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/mythologyli/zju-connect/client/atrust/auth"
+	"github.com/mythologyli/zju-connect/log"
+)
+
+func (c *Client) sessionSID() (string, error) {
+	c.sessionMu.RLock()
+	defer c.sessionMu.RUnlock()
+	return c.SID, c.sessionErr
+}
+
+func (c *Client) setSessionSID(sid string, err error) {
+	c.sessionMu.Lock()
+	c.SID, c.sessionErr = sid, err
+	c.sessionMu.Unlock()
+}
+
+func (c *Client) startSessionRefresh(refresh func(context.Context) (auth.LoginResult, error), data auth.ClientAuthData, save func([]byte) error, interval time.Duration) {
+	c.refreshDone = make(chan struct{})
+	go func() {
+		defer close(c.refreshDone)
+		timer := time.NewTimer(interval)
+		defer timer.Stop()
+		for {
+			select {
+			case <-c.lifecycleCtx.Done():
+				return
+			case <-timer.C:
+			}
+			snapshot, err := refresh(c.lifecycleCtx)
+			if c.lifecycleCtx.Err() != nil {
+				return
+			}
+			if errors.Is(err, auth.ErrSessionInvalid) {
+				c.setSessionSID("", auth.ErrSessionInvalid)
+				log.Printf("aTrust session maintenance stopped: %v", err)
+				return
+			}
+			if err != nil {
+				log.Printf("aTrust authConfig refresh failed: %v", err)
+				timer.Reset(min(interval, time.Minute))
+				continue
+			}
+			oldSID, _ := c.sessionSID()
+			c.setSessionSID(snapshot.SID, nil)
+			log.Printf("aTrust session refreshed (SID changed: %t)", oldSID != snapshot.SID)
+			data.Cookies = snapshot.Cookies
+			if save != nil {
+				encoded, err := json.Marshal(data)
+				if err == nil {
+					err = save(encoded)
+				}
+				if err != nil {
+					log.Printf("Failed to save refreshed aTrust cookies: %v", err)
+				}
+			}
+			timer.Reset(interval)
+		}
+	}()
+}

--- a/client/atrust/session_test.go
+++ b/client/atrust/session_test.go
@@ -1,0 +1,140 @@
+package atrust
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mythologyli/zju-connect/client/atrust/auth"
+)
+
+func TestSessionRefreshPublishesAndPersistsThenStopsOnInvalid(t *testing.T) {
+	c := NewClient(ClientOptions{Session: SessionOptions{SID: "old"}})
+	defer c.Close()
+	persisted := make(chan []byte, 1)
+	calls := 0
+	c.startSessionRefresh(func(ctx context.Context) (auth.LoginResult, error) {
+		calls++
+		if calls == 1 {
+			return auth.LoginResult{SID: "new", Cookies: []auth.Cookie{{Name: "sid", Value: "new"}}}, nil
+		}
+		return auth.LoginResult{}, auth.ErrSessionInvalid
+	}, auth.ClientAuthData{DeviceID: "device", ServerVersionInfo: json.RawMessage(`{"code":0}`)}, func(data []byte) error {
+		if sid, err := c.sessionSID(); sid != "new" || err != nil {
+			t.Errorf("published SID = %q, %v", sid, err)
+		}
+		persisted <- data
+		return nil
+	}, time.Millisecond)
+	select {
+	case <-c.refreshDone:
+	case <-time.After(time.Second):
+		t.Fatal("invalid session did not stop refresh")
+	}
+	if calls != 2 {
+		t.Fatalf("refresh calls = %d", calls)
+	}
+	var saved auth.ClientAuthData
+	select {
+	case data := <-persisted:
+		if err := json.Unmarshal(data, &saved); err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cookies not persisted")
+	}
+	if saved.DeviceID != "device" || len(saved.ServerVersionInfo) == 0 || saved.Cookies[0].Value != "new" {
+		t.Fatalf("saved = %+v", saved)
+	}
+	if _, err := c.DialTCP(context.Background(), &net.TCPAddr{}); !errors.Is(err, auth.ErrSessionInvalid) {
+		t.Fatalf("TCP error = %v", err)
+	}
+	if _, err := (clientInfo{sidProvider: c.sessionSID}).currentSID(); !errors.Is(err, auth.ErrSessionInvalid) {
+		t.Fatalf("L3 error = %v", err)
+	}
+}
+
+func TestSessionRefreshPreservesSIDOnTransientFailureAndCancels(t *testing.T) {
+	c := NewClient(ClientOptions{Session: SessionOptions{SID: "old"}})
+	defer c.Close()
+	second := make(chan struct{})
+	calls := 0
+	c.startSessionRefresh(func(ctx context.Context) (auth.LoginResult, error) {
+		calls++
+		if calls == 1 {
+			return auth.LoginResult{}, errors.New("temporary network error")
+		}
+		close(second)
+		<-ctx.Done()
+		return auth.LoginResult{}, ctx.Err()
+	}, auth.ClientAuthData{}, nil, time.Millisecond)
+	select {
+	case <-second:
+	case <-time.After(time.Second):
+		t.Fatal("no retry")
+	}
+	if sid, err := c.sessionSID(); sid != "old" || err != nil {
+		t.Fatalf("SID = %q, %v", sid, err)
+	}
+	done := make(chan struct{})
+	go func() { c.Close(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not cancel refresh")
+	}
+}
+
+func TestExistingL3InfoUsesCurrentSIDAndSignsIt(t *testing.T) {
+	c := NewClient(ClientOptions{Session: SessionOptions{SID: "old"}})
+	defer c.Close()
+	info := clientInfo{sid: "old", sidProvider: c.sessionSID}
+	meta := packetMeta{atype: 4, proto: 17, srcIP: net.IPv4(192, 0, 2, 1), dstIP: net.IPv4(198, 51, 100, 2), srcPort: 1234, dstPort: 53}
+	for _, sid := range []string{"first", "second"} {
+		c.setSessionSID(sid, nil)
+		data, err := buildAuthRequest(info, []byte("key"), meta, &conntrack{appID: "app", authID: 1})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var req authRequestIP
+		if err := json.Unmarshal(data, &req); err != nil {
+			t.Fatal(err)
+		}
+		if req.Sid != sid {
+			t.Fatalf("wire SID = %q, want %q", req.Sid, sid)
+		}
+		signature := req.XRequestSig
+		req.XRequestSig = ""
+		unsigned, _ := json.Marshal(req)
+		if signature != calcXRequestSig([]byte("key"), unsigned) {
+			t.Fatal("signature did not cover current SID")
+		}
+	}
+	c.setSessionSID("", auth.ErrSessionInvalid)
+	if _, err := buildAuthRequest(info, []byte("key"), meta, &conntrack{}); !errors.Is(err, auth.ErrSessionInvalid) {
+		t.Fatalf("auth error = %v", err)
+	}
+}
+
+func TestConcurrentSessionSIDReaders(t *testing.T) {
+	c := NewClient(ClientOptions{})
+	defer c.Close()
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				c.sessionSID()
+			}
+		}()
+	}
+	for i := 0; i < 1000; i++ {
+		c.setSessionSID("new", nil)
+	}
+	wg.Wait()
+}

--- a/client/atrust/tcptunnel.go
+++ b/client/atrust/tcptunnel.go
@@ -480,6 +480,10 @@ func tcpTunnelRealDstHost(addr *net.TCPAddr, domain string, addrPretend bool) st
 }
 
 func (c *Client) DialTCP(ctx context.Context, addr *net.TCPAddr) (net.Conn, error) {
+	sid, err := c.sessionSID()
+	if err != nil {
+		return nil, err
+	}
 	appID := ""
 	nodeGroupID := ""
 	domain := ""
@@ -542,7 +546,7 @@ func (c *Client) DialTCP(ctx context.Context, addr *net.TCPAddr) (net.Conn, erro
 		return nil, fmt.Errorf("invalid sign key: %w", err)
 	}
 	authRequest := tcpTunnelAuthRequest{
-		SID:          c.SID,
+		SID:          sid,
 		AppID:        appID,
 		URL:          "tcp://" + destAddr,
 		DeviceID:     c.DeviceID,

--- a/config.toml.example
+++ b/config.toml.example
@@ -66,6 +66,7 @@ cas_ticket = ""
 oauth2_code = ""
 phone = ""
 update_best_nodes_interval = 300
+session_refresh_interval = 1800 # aTrust authConfig refresh interval in seconds; 0 disables
 sid = ""
 device_id = ""
 sign_key = ""

--- a/configs/config.go
+++ b/configs/config.go
@@ -59,6 +59,7 @@ type Config struct {
 	SignKey                 string `koanf:"sign_key"`
 	ResourceFile            string `koanf:"resource_file"`
 	UpdateBestNodesInterval int    `koanf:"update_best_nodes_interval"`
+	SessionRefreshInterval  int    `koanf:"session_refresh_interval"`
 }
 
 type SinglePortForwarding struct {
@@ -83,5 +84,6 @@ func Default() Config {
 		SecondaryDNSServer:      "auto",
 		LoginDomain:             "Radius",
 		UpdateBestNodesInterval: 300,
+		SessionRefreshInterval:  1800,
 	}
 }

--- a/init.go
+++ b/init.go
@@ -135,6 +135,7 @@ func newFlagSet(defaults configs.Config) *pflag.FlagSet {
 	flags.String("sign-key", defaults.SignKey, "aTrust Sign Key")
 	flags.String("resource-file", defaults.ResourceFile, "aTrust Resource File")
 	flags.Int("update-best-nodes-interval", defaults.UpdateBestNodesInterval, "Interval to update best nodes in seconds")
+	flags.Int("session-refresh-interval", defaults.SessionRefreshInterval, "aTrust session refresh interval in seconds (0 disables)")
 
 	for _, spec := range collectionSpecs {
 		flags.String(spec.FlagName, "", spec.Help)

--- a/init_test.go
+++ b/init_test.go
@@ -6,6 +6,32 @@ import (
 	"testing"
 )
 
+func TestSessionRefreshConfiguration(t *testing.T) {
+	file := writeConfig(t, "session_refresh_interval = 900\n")
+	for _, tt := range []struct {
+		name string
+		args []string
+		env  []string
+		want int
+	}{
+		{"default", nil, nil, 1800},
+		{"file", []string{"--config", file}, nil, 900},
+		{"environment", []string{"--config", file}, []string{"ZJU_CONNECT_SESSION_REFRESH_INTERVAL=600"}, 600},
+		{"cli", []string{"--config", file, "-session-refresh-interval", "300"}, []string{"ZJU_CONNECT_SESSION_REFRESH_INTERVAL=600"}, 300},
+		{"disabled", []string{"--config", file, "--session-refresh-interval=0"}, nil, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			options, _, err := loadStartupOptions(tt.args, func() []string { return tt.env })
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := options.Config.SessionRefreshInterval; got != tt.want {
+				t.Fatalf("session refresh seconds = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestConfigSourcePrecedence(t *testing.T) {
 	configFile := writeConfig(t, `
 protocol = "atrust"

--- a/main.go
+++ b/main.go
@@ -143,6 +143,7 @@ func main() {
 				log.Printf("Read client data file error: %s", err)
 				log.Println("Will create a new client data file if log in successfully")
 			}
+			log.Printf("Client data will be saved to %s", conf.ClientDataFile)
 		}
 
 		var loginMethod auth.LoginMethod
@@ -173,6 +174,13 @@ func main() {
 			TLSKeyLogWriter: tlsKeyLogWriter,
 		})
 
+		var saveClientDataFunc func(data []byte) error
+		if conf.ClientDataFile != "" {
+			saveClientDataFunc = func(data []byte) error {
+				return os.WriteFile(conf.ClientDataFile, data, 0600)
+			}
+		}
+
 		log.Printf("VPN protocol: %s", conf.Protocol)
 		clientData, err = vpnClient.(*atrustclient.Client).Setup(atrustclient.SetupOptions{
 			ServerAddress:            conf.ServerAddress,
@@ -182,6 +190,8 @@ func main() {
 			ClientData:               clientData,
 			ResourceData:             resourceData,
 			BestNodesRefreshInterval: time.Duration(conf.UpdateBestNodesInterval) * time.Second,
+			SessionRefreshInterval:   time.Duration(conf.SessionRefreshInterval) * time.Second,
+			SaveClientData:           saveClientDataFunc,
 		})
 		if err != nil {
 			vpnClient.(*atrustclient.Client).Close()
@@ -190,14 +200,6 @@ func main() {
 				_ = tlsKeyLogWriter.Close()
 			}
 			log.Fatalf("VPN client setup error: %s", err)
-		}
-
-		if conf.ClientDataFile != "" {
-			err = os.WriteFile(conf.ClientDataFile, clientData, 0644)
-			if err != nil {
-				log.Fatalf("Write client data file error: %s", err)
-			}
-			log.Printf("Client data saved to %s", conf.ClientDataFile)
 		}
 	}
 


### PR DESCRIPTION
修复 aTrust 长时间运行后仍使用旧 SID 导致隧道认证失败的问题。
- 默认每 30 分钟调用 authConfig，读取响应更新后的 Cookie SID，并同步到 TCP/L3 认证。
- 新增 session-refresh-interval 配置，单位为秒，设为 0 禁用定时刷新。
- 初次获取资源后重新读取 SID，并在刷新成功后保存最新 Cookies。
- 临时刷新失败自动重试；明确会话失效时停止维护，提示重新登录；关闭客户端会取消刷新。